### PR TITLE
More options relation to PostgreSQL partitions

### DIFF
--- a/.changeset/some-ravens-attend.md
+++ b/.changeset/some-ravens-attend.md
@@ -1,0 +1,5 @@
+---
+"pg-introspection": patch
+---
+
+Make it easier to get parent and child from PgInherits

--- a/.changeset/ten-cars-burn.md
+++ b/.changeset/ten-cars-burn.md
@@ -1,0 +1,10 @@
+---
+"graphile-build-pg": patch
+"postgraphile": patch
+---
+
+Enable partitions to be exposed via the `@partitionExpose child` or
+`@partitionExpose both` smart tags on the partitioned table. Also adds a global
+configuration option for managing the default setting for this (`parent` by
+default: only expose the parent partitioned table, not its underlying child
+partitions).

--- a/grafast/grafast/__tests__/dcc/dcc-types.ts
+++ b/grafast/grafast/__tests__/dcc/dcc-types.ts
@@ -430,13 +430,13 @@ export type UtilityItem = Item & {
 
 // Generated GraphQL SDK (auto-generated – do not edit)
 
-import type { EnumPlan, EnumValueInput, FieldPlan, InputFieldPlan, GrafastSchemaConfig, InputObjectPlan, InterfacePlan, ObjectPlan, ScalarPlan, Step, UnionPlan } from '../../dist/index.js';
+import type { EnumPlan, EnumValueInput, FieldPlan, InputFieldPlan, GrafastSchemaConfig, InputObjectPlan, InterfacePlan, ObjectPlan, ScalarPlan, Step, UnionPlan, StepRepresentingList } from '../../dist/index.js';
 import { makeGrafastSchema } from '../../dist/index.js';
 import type { Overrides } from './dcc-type-overrides.ts';
 
 type NoArguments = Record<string, never>;
 type NonNullStep<TStep extends Step> = TStep & Step<TStep extends Step<infer U> ? NonNullable<U> : any>;
-type ListOfStep<TStep extends Step> = TStep extends Step<infer U> ? Step<ReadonlyArray<U> | null | undefined> : TStep;
+type ListOfStep<TStep extends Step> = StepRepresentingList<TStep extends Step<infer U> ? U : any, TStep>;
 
 type Get<
   TTypeName extends string,
@@ -455,10 +455,10 @@ export interface TypedGrafastSchemaSpec extends Omit<GrafastSchemaConfig, 'objec
         bestFriend?: FieldPlan<Get<"ActiveCrawler", "source", NonNullStep<Get<"ActiveCrawler", "nullable", Step>>>, NoArguments, Get<"ActiveCrawler", "nullable", Step>>;
         crawlerNumber?: FieldPlan<Get<"ActiveCrawler", "source", NonNullStep<Get<"ActiveCrawler", "nullable", Step>>>, NoArguments, Get<"Int", "nullable", Step>>;
         favouriteItem?: FieldPlan<Get<"ActiveCrawler", "source", NonNullStep<Get<"ActiveCrawler", "nullable", Step>>>, NoArguments, Get<"Item", "nullable", Step>>;
-        friends?: FieldPlan<Get<"ActiveCrawler", "source", NonNullStep<Get<"ActiveCrawler", "nullable", Step>>>, ActiveCrawlerFriendsArgs, ListOfStep<Get<"Character", "nullable", Step>>>;
+        friends?: FieldPlan<Get<"ActiveCrawler", "source", NonNullStep<Get<"ActiveCrawler", "nullable", Step>>>, ActiveCrawlerFriendsArgs, Get<"Character", "list", ListOfStep<Get<"Character", "nullable", Step>>>>;
         friendsConnection?: FieldPlan<Get<"ActiveCrawler", "source", NonNullStep<Get<"ActiveCrawler", "nullable", Step>>>, ActiveCrawlerFriendsConnectionArgs, Get<"CharacterConnection", "nullable", Step>>;
         id?: FieldPlan<Get<"ActiveCrawler", "source", NonNullStep<Get<"ActiveCrawler", "nullable", Step>>>, NoArguments, NonNullStep<Get<"Int", "nullable", Step>>>;
-        items?: FieldPlan<Get<"ActiveCrawler", "source", NonNullStep<Get<"ActiveCrawler", "nullable", Step>>>, ActiveCrawlerItemsArgs, ListOfStep<Get<"Item", "nullable", Step>>>;
+        items?: FieldPlan<Get<"ActiveCrawler", "source", NonNullStep<Get<"ActiveCrawler", "nullable", Step>>>, ActiveCrawlerItemsArgs, Get<"Item", "list", ListOfStep<Get<"Item", "nullable", Step>>>>;
         itemsConnection?: FieldPlan<Get<"ActiveCrawler", "source", NonNullStep<Get<"ActiveCrawler", "nullable", Step>>>, ActiveCrawlerItemsConnectionArgs, Get<"ItemConnection", "nullable", Step>>;
         name?: FieldPlan<Get<"ActiveCrawler", "source", NonNullStep<Get<"ActiveCrawler", "nullable", Step>>>, NoArguments, NonNullStep<Get<"String", "nullable", Step>>>;
         species?: FieldPlan<Get<"ActiveCrawler", "source", NonNullStep<Get<"ActiveCrawler", "nullable", Step>>>, NoArguments, Get<"Species", "nullable", Step>>;
@@ -466,15 +466,15 @@ export interface TypedGrafastSchemaSpec extends Omit<GrafastSchemaConfig, 'objec
     };
     BetaLocation?: Omit<ObjectPlan<Get<"BetaLocation", "source", NonNullStep<Get<"BetaLocation", "nullable", Step>>>>, 'plans'> & {
       plans?: {
-        floors?: FieldPlan<Get<"BetaLocation", "source", NonNullStep<Get<"BetaLocation", "nullable", Step>>>, NoArguments, NonNullStep<ListOfStep<NonNullStep<Get<"Floor", "nullable", Step>>>>>;
+        floors?: FieldPlan<Get<"BetaLocation", "source", NonNullStep<Get<"BetaLocation", "nullable", Step>>>, NoArguments, NonNullStep<Get<"Floor", "list", ListOfStep<NonNullStep<Get<"Floor", "nullable", Step>>>>>>;
         id?: FieldPlan<Get<"BetaLocation", "source", NonNullStep<Get<"BetaLocation", "nullable", Step>>>, NoArguments, NonNullStep<Get<"Int", "nullable", Step>>>;
         name?: FieldPlan<Get<"BetaLocation", "source", NonNullStep<Get<"BetaLocation", "nullable", Step>>>, NoArguments, NonNullStep<Get<"String", "nullable", Step>>>;
       }
     };
     CharacterConnection?: Omit<ObjectPlan<Get<"CharacterConnection", "source", NonNullStep<Get<"CharacterConnection", "nullable", Step>>>>, 'plans'> & {
       plans?: {
-        edges?: FieldPlan<Get<"CharacterConnection", "source", NonNullStep<Get<"CharacterConnection", "nullable", Step>>>, NoArguments, ListOfStep<Get<"CharacterEdge", "nullable", Step>>>;
-        nodes?: FieldPlan<Get<"CharacterConnection", "source", NonNullStep<Get<"CharacterConnection", "nullable", Step>>>, NoArguments, ListOfStep<Get<"Character", "nullable", Step>>>;
+        edges?: FieldPlan<Get<"CharacterConnection", "source", NonNullStep<Get<"CharacterConnection", "nullable", Step>>>, NoArguments, Get<"CharacterEdge", "list", ListOfStep<Get<"CharacterEdge", "nullable", Step>>>>;
+        nodes?: FieldPlan<Get<"CharacterConnection", "source", NonNullStep<Get<"CharacterConnection", "nullable", Step>>>, NoArguments, Get<"Character", "list", ListOfStep<Get<"Character", "nullable", Step>>>>;
         pageInfo?: FieldPlan<Get<"CharacterConnection", "source", NonNullStep<Get<"CharacterConnection", "nullable", Step>>>, NoArguments, NonNullStep<Get<"PageInfo", "nullable", Step>>>;
       }
     };
@@ -486,19 +486,19 @@ export interface TypedGrafastSchemaSpec extends Omit<GrafastSchemaConfig, 'objec
     };
     Club?: Omit<ObjectPlan<Get<"Club", "source", NonNullStep<Get<"Club", "nullable", Step>>>>, 'plans'> & {
       plans?: {
-        floors?: FieldPlan<Get<"Club", "source", NonNullStep<Get<"Club", "nullable", Step>>>, NoArguments, NonNullStep<ListOfStep<NonNullStep<Get<"Floor", "nullable", Step>>>>>;
+        floors?: FieldPlan<Get<"Club", "source", NonNullStep<Get<"Club", "nullable", Step>>>, NoArguments, NonNullStep<Get<"Floor", "list", ListOfStep<NonNullStep<Get<"Floor", "nullable", Step>>>>>>;
         id?: FieldPlan<Get<"Club", "source", NonNullStep<Get<"Club", "nullable", Step>>>, NoArguments, NonNullStep<Get<"Int", "nullable", Step>>>;
         manager?: FieldPlan<Get<"Club", "source", NonNullStep<Get<"Club", "nullable", Step>>>, NoArguments, Get<"NPC", "nullable", Step>>;
         name?: FieldPlan<Get<"Club", "source", NonNullStep<Get<"Club", "nullable", Step>>>, NoArguments, NonNullStep<Get<"String", "nullable", Step>>>;
-        security?: FieldPlan<Get<"Club", "source", NonNullStep<Get<"Club", "nullable", Step>>>, NoArguments, ListOfStep<NonNullStep<Get<"Security", "nullable", Step>>>>;
-        stock?: FieldPlan<Get<"Club", "source", NonNullStep<Get<"Club", "nullable", Step>>>, NoArguments, ListOfStep<Get<"ClubStock", "nullable", Step>>>;
+        security?: FieldPlan<Get<"Club", "source", NonNullStep<Get<"Club", "nullable", Step>>>, NoArguments, Get<"Security", "list", ListOfStep<NonNullStep<Get<"Security", "nullable", Step>>>>>;
+        stock?: FieldPlan<Get<"Club", "source", NonNullStep<Get<"Club", "nullable", Step>>>, NoArguments, Get<"ClubStock", "list", ListOfStep<Get<"ClubStock", "nullable", Step>>>>;
         tagline?: FieldPlan<Get<"Club", "source", NonNullStep<Get<"Club", "nullable", Step>>>, NoArguments, NonNullStep<Get<"String", "nullable", Step>>>;
       }
     };
     Consumable?: Omit<ObjectPlan<Get<"Consumable", "source", NonNullStep<Get<"Consumable", "nullable", Step>>>>, 'plans'> & {
       plans?: {
-        canBeFoundIn?: FieldPlan<Get<"Consumable", "source", NonNullStep<Get<"Consumable", "nullable", Step>>>, NoArguments, ListOfStep<Get<"LootBox", "nullable", Step>>>;
-        contents?: FieldPlan<Get<"Consumable", "source", NonNullStep<Get<"Consumable", "nullable", Step>>>, ConsumableContentsArgs, ListOfStep<Get<"Item", "nullable", Step>>>;
+        canBeFoundIn?: FieldPlan<Get<"Consumable", "source", NonNullStep<Get<"Consumable", "nullable", Step>>>, NoArguments, Get<"LootBox", "list", ListOfStep<Get<"LootBox", "nullable", Step>>>>;
+        contents?: FieldPlan<Get<"Consumable", "source", NonNullStep<Get<"Consumable", "nullable", Step>>>, ConsumableContentsArgs, Get<"Item", "list", ListOfStep<Get<"Item", "nullable", Step>>>>;
         creator?: FieldPlan<Get<"Consumable", "source", NonNullStep<Get<"Consumable", "nullable", Step>>>, NoArguments, Get<"Crawler", "nullable", Step>>;
         effect?: FieldPlan<Get<"Consumable", "source", NonNullStep<Get<"Consumable", "nullable", Step>>>, NoArguments, Get<"String", "nullable", Step>>;
         id?: FieldPlan<Get<"Consumable", "source", NonNullStep<Get<"Consumable", "nullable", Step>>>, NoArguments, NonNullStep<Get<"Int", "nullable", Step>>>;
@@ -514,8 +514,8 @@ export interface TypedGrafastSchemaSpec extends Omit<GrafastSchemaConfig, 'objec
     };
     Equipment?: Omit<ObjectPlan<Get<"Equipment", "source", NonNullStep<Get<"Equipment", "nullable", Step>>>>, 'plans'> & {
       plans?: {
-        canBeFoundIn?: FieldPlan<Get<"Equipment", "source", NonNullStep<Get<"Equipment", "nullable", Step>>>, NoArguments, ListOfStep<Get<"LootBox", "nullable", Step>>>;
-        contents?: FieldPlan<Get<"Equipment", "source", NonNullStep<Get<"Equipment", "nullable", Step>>>, EquipmentContentsArgs, ListOfStep<Get<"Item", "nullable", Step>>>;
+        canBeFoundIn?: FieldPlan<Get<"Equipment", "source", NonNullStep<Get<"Equipment", "nullable", Step>>>, NoArguments, Get<"LootBox", "list", ListOfStep<Get<"LootBox", "nullable", Step>>>>;
+        contents?: FieldPlan<Get<"Equipment", "source", NonNullStep<Get<"Equipment", "nullable", Step>>>, EquipmentContentsArgs, Get<"Item", "list", ListOfStep<Get<"Item", "nullable", Step>>>>;
         creator?: FieldPlan<Get<"Equipment", "source", NonNullStep<Get<"Equipment", "nullable", Step>>>, NoArguments, Get<"Crawler", "nullable", Step>>;
         currentDurability?: FieldPlan<Get<"Equipment", "source", NonNullStep<Get<"Equipment", "nullable", Step>>>, NoArguments, Get<"Int", "nullable", Step>>;
         id?: FieldPlan<Get<"Equipment", "source", NonNullStep<Get<"Equipment", "nullable", Step>>>, NoArguments, NonNullStep<Get<"Int", "nullable", Step>>>;
@@ -525,7 +525,7 @@ export interface TypedGrafastSchemaSpec extends Omit<GrafastSchemaConfig, 'objec
     };
     Floor?: Omit<ObjectPlan<Get<"Floor", "source", NonNullStep<Get<"Floor", "nullable", Step>>>>, 'plans'> & {
       plans?: {
-        locations?: FieldPlan<Get<"Floor", "source", NonNullStep<Get<"Floor", "nullable", Step>>>, NoArguments, ListOfStep<Get<"Location", "nullable", Step>>>;
+        locations?: FieldPlan<Get<"Floor", "source", NonNullStep<Get<"Floor", "nullable", Step>>>, NoArguments, Get<"Location", "list", ListOfStep<Get<"Location", "nullable", Step>>>>;
         number?: FieldPlan<Get<"Floor", "source", NonNullStep<Get<"Floor", "nullable", Step>>>, NoArguments, NonNullStep<Get<"Int", "nullable", Step>>>;
       }
     };
@@ -533,7 +533,7 @@ export interface TypedGrafastSchemaSpec extends Omit<GrafastSchemaConfig, 'objec
       plans?: {
         bestFriend?: FieldPlan<Get<"Guide", "source", NonNullStep<Get<"Guide", "nullable", Step>>>, NoArguments, Get<"Character", "nullable", Step>>;
         exCrawler?: FieldPlan<Get<"Guide", "source", NonNullStep<Get<"Guide", "nullable", Step>>>, NoArguments, Get<"Boolean", "nullable", Step>>;
-        friends?: FieldPlan<Get<"Guide", "source", NonNullStep<Get<"Guide", "nullable", Step>>>, GuideFriendsArgs, ListOfStep<Get<"Character", "nullable", Step>>>;
+        friends?: FieldPlan<Get<"Guide", "source", NonNullStep<Get<"Guide", "nullable", Step>>>, GuideFriendsArgs, Get<"Character", "list", ListOfStep<Get<"Character", "nullable", Step>>>>;
         id?: FieldPlan<Get<"Guide", "source", NonNullStep<Get<"Guide", "nullable", Step>>>, NoArguments, NonNullStep<Get<"Int", "nullable", Step>>>;
         name?: FieldPlan<Get<"Guide", "source", NonNullStep<Get<"Guide", "nullable", Step>>>, NoArguments, NonNullStep<Get<"String", "nullable", Step>>>;
         saferoomLocation?: FieldPlan<Get<"Guide", "source", NonNullStep<Get<"Guide", "nullable", Step>>>, NoArguments, Get<"String", "nullable", Step>>;
@@ -542,8 +542,8 @@ export interface TypedGrafastSchemaSpec extends Omit<GrafastSchemaConfig, 'objec
     };
     ItemConnection?: Omit<ObjectPlan<Get<"ItemConnection", "source", NonNullStep<Get<"ItemConnection", "nullable", Step>>>>, 'plans'> & {
       plans?: {
-        edges?: FieldPlan<Get<"ItemConnection", "source", NonNullStep<Get<"ItemConnection", "nullable", Step>>>, NoArguments, ListOfStep<Get<"ItemEdge", "nullable", Step>>>;
-        nodes?: FieldPlan<Get<"ItemConnection", "source", NonNullStep<Get<"ItemConnection", "nullable", Step>>>, NoArguments, ListOfStep<Get<"Item", "nullable", Step>>>;
+        edges?: FieldPlan<Get<"ItemConnection", "source", NonNullStep<Get<"ItemConnection", "nullable", Step>>>, NoArguments, Get<"ItemEdge", "list", ListOfStep<Get<"ItemEdge", "nullable", Step>>>>;
+        nodes?: FieldPlan<Get<"ItemConnection", "source", NonNullStep<Get<"ItemConnection", "nullable", Step>>>, NoArguments, Get<"Item", "list", ListOfStep<Get<"Item", "nullable", Step>>>>;
         pageInfo?: FieldPlan<Get<"ItemConnection", "source", NonNullStep<Get<"ItemConnection", "nullable", Step>>>, NoArguments, NonNullStep<Get<"PageInfo", "nullable", Step>>>;
       }
     };
@@ -557,7 +557,7 @@ export interface TypedGrafastSchemaSpec extends Omit<GrafastSchemaConfig, 'objec
       plans?: {
         category?: FieldPlan<Get<"LootBox", "source", NonNullStep<Get<"LootBox", "nullable", Step>>>, NoArguments, Get<"String", "nullable", Step>>;
         id?: FieldPlan<Get<"LootBox", "source", NonNullStep<Get<"LootBox", "nullable", Step>>>, NoArguments, NonNullStep<Get<"Int", "nullable", Step>>>;
-        possibleItems?: FieldPlan<Get<"LootBox", "source", NonNullStep<Get<"LootBox", "nullable", Step>>>, NoArguments, ListOfStep<Get<"Item", "nullable", Step>>>;
+        possibleItems?: FieldPlan<Get<"LootBox", "source", NonNullStep<Get<"LootBox", "nullable", Step>>>, NoArguments, Get<"Item", "list", ListOfStep<Get<"Item", "nullable", Step>>>>;
         tier?: FieldPlan<Get<"LootBox", "source", NonNullStep<Get<"LootBox", "nullable", Step>>>, NoArguments, Get<"String", "nullable", Step>>;
       }
     };
@@ -575,9 +575,9 @@ export interface TypedGrafastSchemaSpec extends Omit<GrafastSchemaConfig, 'objec
         bestFriend?: FieldPlan<Get<"Manager", "source", NonNullStep<Get<"Manager", "nullable", Step>>>, NoArguments, Get<"Character", "nullable", Step>>;
         client?: FieldPlan<Get<"Manager", "source", NonNullStep<Get<"Manager", "nullable", Step>>>, NoArguments, Get<"ActiveCrawler", "nullable", Step>>;
         exCrawler?: FieldPlan<Get<"Manager", "source", NonNullStep<Get<"Manager", "nullable", Step>>>, NoArguments, Get<"Boolean", "nullable", Step>>;
-        friends?: FieldPlan<Get<"Manager", "source", NonNullStep<Get<"Manager", "nullable", Step>>>, ManagerFriendsArgs, ListOfStep<Get<"Character", "nullable", Step>>>;
+        friends?: FieldPlan<Get<"Manager", "source", NonNullStep<Get<"Manager", "nullable", Step>>>, ManagerFriendsArgs, Get<"Character", "list", ListOfStep<Get<"Character", "nullable", Step>>>>;
         id?: FieldPlan<Get<"Manager", "source", NonNullStep<Get<"Manager", "nullable", Step>>>, NoArguments, NonNullStep<Get<"Int", "nullable", Step>>>;
-        items?: FieldPlan<Get<"Manager", "source", NonNullStep<Get<"Manager", "nullable", Step>>>, ManagerItemsArgs, ListOfStep<Get<"Item", "nullable", Step>>>;
+        items?: FieldPlan<Get<"Manager", "source", NonNullStep<Get<"Manager", "nullable", Step>>>, ManagerItemsArgs, Get<"Item", "list", ListOfStep<Get<"Item", "nullable", Step>>>>;
         itemsConnection?: FieldPlan<Get<"Manager", "source", NonNullStep<Get<"Manager", "nullable", Step>>>, ManagerItemsConnectionArgs, Get<"ItemConnection", "nullable", Step>>;
         name?: FieldPlan<Get<"Manager", "source", NonNullStep<Get<"Manager", "nullable", Step>>>, NoArguments, NonNullStep<Get<"String", "nullable", Step>>>;
         species?: FieldPlan<Get<"Manager", "source", NonNullStep<Get<"Manager", "nullable", Step>>>, NoArguments, Get<"Species", "nullable", Step>>;
@@ -585,7 +585,7 @@ export interface TypedGrafastSchemaSpec extends Omit<GrafastSchemaConfig, 'objec
     };
     MiscItem?: Omit<ObjectPlan<Get<"MiscItem", "source", NonNullStep<Get<"MiscItem", "nullable", Step>>>>, 'plans'> & {
       plans?: {
-        canBeFoundIn?: FieldPlan<Get<"MiscItem", "source", NonNullStep<Get<"MiscItem", "nullable", Step>>>, NoArguments, ListOfStep<Get<"LootBox", "nullable", Step>>>;
+        canBeFoundIn?: FieldPlan<Get<"MiscItem", "source", NonNullStep<Get<"MiscItem", "nullable", Step>>>, NoArguments, Get<"LootBox", "list", ListOfStep<Get<"LootBox", "nullable", Step>>>>;
         id?: FieldPlan<Get<"MiscItem", "source", NonNullStep<Get<"MiscItem", "nullable", Step>>>, NoArguments, NonNullStep<Get<"Int", "nullable", Step>>>;
         name?: FieldPlan<Get<"MiscItem", "source", NonNullStep<Get<"MiscItem", "nullable", Step>>>, NoArguments, Get<"String", "nullable", Step>>;
       }
@@ -610,20 +610,20 @@ export interface TypedGrafastSchemaSpec extends Omit<GrafastSchemaConfig, 'objec
     };
     SafeRoom?: Omit<ObjectPlan<Get<"SafeRoom", "source", NonNullStep<Get<"SafeRoom", "nullable", Step>>>>, 'plans'> & {
       plans?: {
-        floors?: FieldPlan<Get<"SafeRoom", "source", NonNullStep<Get<"SafeRoom", "nullable", Step>>>, NoArguments, NonNullStep<ListOfStep<NonNullStep<Get<"Floor", "nullable", Step>>>>>;
+        floors?: FieldPlan<Get<"SafeRoom", "source", NonNullStep<Get<"SafeRoom", "nullable", Step>>>, NoArguments, NonNullStep<Get<"Floor", "list", ListOfStep<NonNullStep<Get<"Floor", "nullable", Step>>>>>>;
         hasPersonalSpace?: FieldPlan<Get<"SafeRoom", "source", NonNullStep<Get<"SafeRoom", "nullable", Step>>>, NoArguments, Get<"Boolean", "nullable", Step>>;
         id?: FieldPlan<Get<"SafeRoom", "source", NonNullStep<Get<"SafeRoom", "nullable", Step>>>, NoArguments, NonNullStep<Get<"Int", "nullable", Step>>>;
         manager?: FieldPlan<Get<"SafeRoom", "source", NonNullStep<Get<"SafeRoom", "nullable", Step>>>, NoArguments, Get<"NPC", "nullable", Step>>;
         name?: FieldPlan<Get<"SafeRoom", "source", NonNullStep<Get<"SafeRoom", "nullable", Step>>>, NoArguments, NonNullStep<Get<"String", "nullable", Step>>>;
-        stock?: FieldPlan<Get<"SafeRoom", "source", NonNullStep<Get<"SafeRoom", "nullable", Step>>>, NoArguments, ListOfStep<Get<"SafeRoomStock", "nullable", Step>>>;
+        stock?: FieldPlan<Get<"SafeRoom", "source", NonNullStep<Get<"SafeRoom", "nullable", Step>>>, NoArguments, Get<"SafeRoomStock", "list", ListOfStep<Get<"SafeRoomStock", "nullable", Step>>>>;
       }
     };
     Security?: Omit<ObjectPlan<Get<"Security", "source", NonNullStep<Get<"Security", "nullable", Step>>>>, 'plans'> & {
       plans?: {
         bestFriend?: FieldPlan<Get<"Security", "source", NonNullStep<Get<"Security", "nullable", Step>>>, NoArguments, Get<"Character", "nullable", Step>>;
-        clients?: FieldPlan<Get<"Security", "source", NonNullStep<Get<"Security", "nullable", Step>>>, NoArguments, ListOfStep<NonNullStep<Get<"ActiveCrawler", "nullable", Step>>>>;
+        clients?: FieldPlan<Get<"Security", "source", NonNullStep<Get<"Security", "nullable", Step>>>, NoArguments, Get<"ActiveCrawler", "list", ListOfStep<NonNullStep<Get<"ActiveCrawler", "nullable", Step>>>>>;
         exCrawler?: FieldPlan<Get<"Security", "source", NonNullStep<Get<"Security", "nullable", Step>>>, NoArguments, Get<"Boolean", "nullable", Step>>;
-        friends?: FieldPlan<Get<"Security", "source", NonNullStep<Get<"Security", "nullable", Step>>>, SecurityFriendsArgs, ListOfStep<Get<"Character", "nullable", Step>>>;
+        friends?: FieldPlan<Get<"Security", "source", NonNullStep<Get<"Security", "nullable", Step>>>, SecurityFriendsArgs, Get<"Character", "list", ListOfStep<Get<"Character", "nullable", Step>>>>;
         id?: FieldPlan<Get<"Security", "source", NonNullStep<Get<"Security", "nullable", Step>>>, NoArguments, NonNullStep<Get<"Int", "nullable", Step>>>;
         name?: FieldPlan<Get<"Security", "source", NonNullStep<Get<"Security", "nullable", Step>>>, NoArguments, NonNullStep<Get<"String", "nullable", Step>>>;
         species?: FieldPlan<Get<"Security", "source", NonNullStep<Get<"Security", "nullable", Step>>>, NoArguments, Get<"Species", "nullable", Step>>;
@@ -633,9 +633,9 @@ export interface TypedGrafastSchemaSpec extends Omit<GrafastSchemaConfig, 'objec
       plans?: {
         bestFriend?: FieldPlan<Get<"Staff", "source", NonNullStep<Get<"Staff", "nullable", Step>>>, NoArguments, Get<"Character", "nullable", Step>>;
         exCrawler?: FieldPlan<Get<"Staff", "source", NonNullStep<Get<"Staff", "nullable", Step>>>, NoArguments, Get<"Boolean", "nullable", Step>>;
-        friends?: FieldPlan<Get<"Staff", "source", NonNullStep<Get<"Staff", "nullable", Step>>>, StaffFriendsArgs, ListOfStep<Get<"Character", "nullable", Step>>>;
+        friends?: FieldPlan<Get<"Staff", "source", NonNullStep<Get<"Staff", "nullable", Step>>>, StaffFriendsArgs, Get<"Character", "list", ListOfStep<Get<"Character", "nullable", Step>>>>;
         id?: FieldPlan<Get<"Staff", "source", NonNullStep<Get<"Staff", "nullable", Step>>>, NoArguments, NonNullStep<Get<"Int", "nullable", Step>>>;
-        items?: FieldPlan<Get<"Staff", "source", NonNullStep<Get<"Staff", "nullable", Step>>>, StaffItemsArgs, ListOfStep<Get<"Item", "nullable", Step>>>;
+        items?: FieldPlan<Get<"Staff", "source", NonNullStep<Get<"Staff", "nullable", Step>>>, StaffItemsArgs, Get<"Item", "list", ListOfStep<Get<"Item", "nullable", Step>>>>;
         itemsConnection?: FieldPlan<Get<"Staff", "source", NonNullStep<Get<"Staff", "nullable", Step>>>, StaffItemsConnectionArgs, Get<"ItemConnection", "nullable", Step>>;
         name?: FieldPlan<Get<"Staff", "source", NonNullStep<Get<"Staff", "nullable", Step>>>, NoArguments, NonNullStep<Get<"String", "nullable", Step>>>;
         species?: FieldPlan<Get<"Staff", "source", NonNullStep<Get<"Staff", "nullable", Step>>>, NoArguments, Get<"Species", "nullable", Step>>;
@@ -643,14 +643,14 @@ export interface TypedGrafastSchemaSpec extends Omit<GrafastSchemaConfig, 'objec
     };
     Stairwell?: Omit<ObjectPlan<Get<"Stairwell", "source", NonNullStep<Get<"Stairwell", "nullable", Step>>>>, 'plans'> & {
       plans?: {
-        floors?: FieldPlan<Get<"Stairwell", "source", NonNullStep<Get<"Stairwell", "nullable", Step>>>, NoArguments, NonNullStep<ListOfStep<NonNullStep<Get<"Floor", "nullable", Step>>>>>;
+        floors?: FieldPlan<Get<"Stairwell", "source", NonNullStep<Get<"Stairwell", "nullable", Step>>>, NoArguments, NonNullStep<Get<"Floor", "list", ListOfStep<NonNullStep<Get<"Floor", "nullable", Step>>>>>>;
         id?: FieldPlan<Get<"Stairwell", "source", NonNullStep<Get<"Stairwell", "nullable", Step>>>, NoArguments, NonNullStep<Get<"Int", "nullable", Step>>>;
         name?: FieldPlan<Get<"Stairwell", "source", NonNullStep<Get<"Stairwell", "nullable", Step>>>, NoArguments, NonNullStep<Get<"String", "nullable", Step>>>;
       }
     };
     UtilityItem?: Omit<ObjectPlan<Get<"UtilityItem", "source", NonNullStep<Get<"UtilityItem", "nullable", Step>>>>, 'plans'> & {
       plans?: {
-        canBeFoundIn?: FieldPlan<Get<"UtilityItem", "source", NonNullStep<Get<"UtilityItem", "nullable", Step>>>, NoArguments, ListOfStep<Get<"LootBox", "nullable", Step>>>;
+        canBeFoundIn?: FieldPlan<Get<"UtilityItem", "source", NonNullStep<Get<"UtilityItem", "nullable", Step>>>, NoArguments, Get<"LootBox", "list", ListOfStep<Get<"LootBox", "nullable", Step>>>>;
         id?: FieldPlan<Get<"UtilityItem", "source", NonNullStep<Get<"UtilityItem", "nullable", Step>>>, NoArguments, NonNullStep<Get<"Int", "nullable", Step>>>;
         name?: FieldPlan<Get<"UtilityItem", "source", NonNullStep<Get<"UtilityItem", "nullable", Step>>>, NoArguments, Get<"String", "nullable", Step>>;
       }

--- a/graphile-build/graphile-build-pg/src/index.ts
+++ b/graphile-build/graphile-build-pg/src/index.ts
@@ -1,4 +1,6 @@
 import type { PgRegistry } from "@dataplan/pg";
+
+import type { PartitionParentMode } from "./interfaces.js";
 export { PgAllRowsPlugin } from "./plugins/PgAllRowsPlugin.js";
 export { PgAttributeDeprecationPlugin } from "./plugins/PgAttributeDeprecationPlugin.js";
 export { PgAttributesPlugin } from "./plugins/PgAttributesPlugin.js";
@@ -104,6 +106,10 @@ declare global {
 
     interface BuildInput {
       pgRegistry: PgRegistry;
+    }
+
+    interface SchemaOptions {
+      pgDefaultPartitionedTableMode?: PartitionParentMode;
     }
   }
 

--- a/graphile-build/graphile-build-pg/src/index.ts
+++ b/graphile-build/graphile-build-pg/src/index.ts
@@ -1,6 +1,6 @@
 import type { PgRegistry } from "@dataplan/pg";
 
-import type { PartitionParentMode } from "./interfaces.js";
+import type { PartitionExpose } from "./interfaces.js";
 export { PgAllRowsPlugin } from "./plugins/PgAllRowsPlugin.js";
 export { PgAttributeDeprecationPlugin } from "./plugins/PgAttributeDeprecationPlugin.js";
 export { PgAttributesPlugin } from "./plugins/PgAttributesPlugin.js";
@@ -109,7 +109,17 @@ declare global {
     }
 
     interface SchemaOptions {
-      pgDefaultPartitionedTableMode?: PartitionParentMode;
+      /**
+       * What to expose when we see a partitioned table (or its child partitions).
+       *
+       * - `parent` - only expose the parent (partitioned) table, not the
+       *   children (partitions)
+       * - `child` - only expose the children (partitions), not the parent
+       *   partitioned table
+       * - `both` - expose both the parent (partitioned) table and all of its
+       *   partitions
+       */
+      pgDefaultPartitionedTableExpose?: PartitionExpose;
     }
   }
 

--- a/graphile-build/graphile-build-pg/src/index.ts
+++ b/graphile-build/graphile-build-pg/src/index.ts
@@ -64,6 +64,9 @@ declare global {
 
       /** For enum tables; we shouldn't expose these through GraphQL */
       enum: string | true;
+
+      /** For partitioned tables */
+      partitionExpose: PartitionExpose;
     }
 
     interface PgResourceUniqueTags extends PgSmartTagsDict {

--- a/graphile-build/graphile-build-pg/src/interfaces.ts
+++ b/graphile-build/graphile-build-pg/src/interfaces.ts
@@ -1,0 +1,2 @@
+export const PARTITION_PARENT_MODES = ["both", "child", "parent"] as const;
+export type PartitionParentMode = (typeof PARTITION_PARENT_MODES)[number];

--- a/graphile-build/graphile-build-pg/src/interfaces.ts
+++ b/graphile-build/graphile-build-pg/src/interfaces.ts
@@ -1,2 +1,2 @@
-export const PARTITION_PARENT_MODES = ["both", "child", "parent"] as const;
-export type PartitionParentMode = (typeof PARTITION_PARENT_MODES)[number];
+export const PARTITION_EXPOSE_OPTIONS = ["both", "child", "parent"] as const;
+export type PartitionExpose = (typeof PARTITION_EXPOSE_OPTIONS)[number];

--- a/graphile-build/graphile-build-pg/src/plugins/PgIntrospectionPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgIntrospectionPlugin.ts
@@ -133,6 +133,10 @@ declare global {
           serviceName: string,
           classId: string,
         ): Promise<PgInherits[]>;
+        getInheritanceChildrenForClass(
+          serviceName: string,
+          classId: string,
+        ): Promise<PgInherits[]>;
         getNamespaceByName(
           serviceName: string,
           namespaceName: string,
@@ -446,6 +450,13 @@ export const PgIntrospectionPlugin: GraphileConfig.Plugin = {
         const list = relevant.introspection.inherits;
         // PERF: cache
         return list.filter((entity) => entity.inhrelid === classId);
+      },
+
+      async getInheritanceChildrenForClass(info, serviceName, classId) {
+        const relevant = await getDb(info, serviceName);
+        const list = relevant.introspection.inherits;
+        // PERF: cache
+        return list.filter((entity) => entity.inhparent === classId);
       },
 
       async getNamespaceByName(info, serviceName, name) {

--- a/graphile-build/graphile-build-pg/src/plugins/PgRelationsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgRelationsPlugin.ts
@@ -297,8 +297,15 @@ export const PgRelationsPlugin: GraphileConfig.Plugin = {
         const foreignClass = isReferencee
           ? pgConstraint.getClass()
           : pgConstraint.getForeignClass();
-        if (!pgClass || !foreignClass) {
-          throw new Error(`Invalid introspection`);
+        if (!pgClass) {
+          throw new Error(
+            `Invalid introspection: ${pgConstraint.contype} constraint ${pgConstraint.conname} can't read class ${pgConstraint.conrelid}`,
+          );
+        }
+        if (!foreignClass) {
+          throw new Error(
+            `Invalid introspection: ${pgConstraint.contype} constraint ${pgConstraint.conname} on ${pgClass.relname}; can't read foreign class ${pgConstraint.confrelid}`,
+          );
         }
         const localAttributeNumbers = isReferencee
           ? pgConstraint.confkey!

--- a/graphile-build/graphile-build-pg/src/plugins/PgRelationsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgRelationsPlugin.ts
@@ -570,6 +570,9 @@ export const PgRelationsPlugin: GraphileConfig.Plugin = {
     entityBehavior: {
       pgCodecRelation: {
         inferred(behavior, entity): GraphileBuild.BehaviorString[] {
+          if (entity.remoteResource.extensions?.partitionParent) {
+            return [behavior, "-*"];
+          }
           if (entity.isUnique) {
             return [
               "resource:select",

--- a/graphile-build/graphile-build-pg/src/plugins/PgRelationsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgRelationsPlugin.ts
@@ -34,6 +34,12 @@ const ref_sql = te.ref(sql, "sql");
 
 declare global {
   namespace GraphileBuild {
+    interface Build {
+      pgExcludeDueToPartitioning(
+        this: GraphileBuild.Build,
+        resource: PgResource<any, any, any, any, any>,
+      ): boolean;
+    }
     interface BehaviorStrings {
       "singularRelation:resource:single": true;
       "singularRelation:resource:list": true;
@@ -569,8 +575,8 @@ export const PgRelationsPlugin: GraphileConfig.Plugin = {
     },
     entityBehavior: {
       pgCodecRelation: {
-        inferred(behavior, entity): GraphileBuild.BehaviorString[] {
-          if (entity.remoteResource.extensions?.partitionParent) {
+        inferred(behavior, entity, build): GraphileBuild.BehaviorString[] {
+          if (build.pgExcludeDueToPartitioning(entity.remoteResource)) {
             return [behavior, "-*"];
           }
           if (entity.isUnique) {

--- a/graphile-build/graphile-build-pg/src/plugins/PgTablesPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgTablesPlugin.ts
@@ -15,8 +15,8 @@ import {
 import type { PgClass, PgConstraint, PgNamespace } from "pg-introspection";
 
 import {
-  PARTITION_PARENT_MODES,
-  type PartitionParentMode,
+  PARTITION_EXPOSE_OPTIONS,
+  type PartitionExpose,
 } from "../interfaces.js";
 import { exportNameHint } from "../utils.js";
 import { version } from "../version.js";
@@ -933,8 +933,8 @@ function partitionExclude(
   if (!pp && !hasPartitions) {
     return INCLUDE;
   }
-  const DEFAULT_PARTITION_PARENT_MODE: PartitionParentMode =
-    build.options.pgDefaultPartitionedTableMode ?? "parent";
+  const DEFAULT_PARTITION_PARENT_MODE: PartitionExpose =
+    build.options.pgDefaultPartitionedTableExpose ?? "parent";
   const parentMode = getPartitionParentMode(build, resource);
   if (hasPartitions) {
     const directMode = partitionMode(resource);
@@ -1036,26 +1036,26 @@ function getPartitionParent(
 function getPartitionParentMode(
   build: GraphileBuild.Build,
   resource: PgResource,
-): PartitionParentMode | null {
+): PartitionExpose | null {
   const parentResource = getPartitionParent(build, resource);
   return parentResource ? partitionMode(parentResource) : null;
 }
 
 function partitionMode(
   resource: PgResource<any, any, any, any, any>,
-): PartitionParentMode | null {
+): PartitionExpose | null {
   const partitionTag = resource.extensions?.tags?.partition;
   if (typeof partitionTag === "string") {
-    if (PARTITION_PARENT_MODES.includes(partitionTag as PartitionParentMode)) {
-      return partitionTag as PartitionParentMode;
+    if (PARTITION_EXPOSE_OPTIONS.includes(partitionTag as PartitionExpose)) {
+      return partitionTag as PartitionExpose;
     } else {
       throw new Error(
-        `"@partition ${partitionTag}" on resource '${resource.name}' not understood; must be one of: '${PARTITION_PARENT_MODES.join("', '")}'`,
+        `"@partition ${partitionTag}" on resource '${resource.name}' not understood; must be one of: '${PARTITION_EXPOSE_OPTIONS.join("', '")}'`,
       );
     }
   } else if (partitionTag != null) {
     throw new Error(
-      `@partition on resource '${resource.name}' not understood; must be one of: '${PARTITION_PARENT_MODES.join("', '")}'`,
+      `@partition on resource '${resource.name}' not understood; must be one of: '${PARTITION_EXPOSE_OPTIONS.join("', '")}'`,
     );
   } else {
     return null;

--- a/graphile-build/graphile-build-pg/src/plugins/PgTablesPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgTablesPlugin.ts
@@ -403,11 +403,17 @@ export const PgTablesPlugin: GraphileConfig.Plugin = {
               );
             }),
           );
-          const constraints = [
-            // TODO: handle multiple inheritance
-            ...inheritedConstraints.flatMap((list) => list),
-            ...directConstraints,
-          ];
+          const constraints =
+            // Partitions only have their own local constraints
+            pgClass.relispartition
+              ? directConstraints
+              : // Table inheritance, on the other hand, needs to manually inherit constraints (?)
+                // TODO: Check this, I'm unconvinced.
+                [
+                  // TODO: handle multiple inheritance
+                  ...inheritedConstraints.flatMap((list) => list),
+                  ...directConstraints,
+                ];
           const uniqueAttributeOnlyConstraints = constraints.filter(
             (c) =>
               ["u", "p"].includes(c.contype) && c.conkey?.every((k) => k > 0),

--- a/graphile-build/graphile-build-pg/src/plugins/PgTablesPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgTablesPlugin.ts
@@ -1044,18 +1044,18 @@ function getPartitionParentMode(
 function partitionMode(
   resource: PgResource<any, any, any, any, any>,
 ): PartitionExpose | null {
-  const partitionTag = resource.extensions?.tags?.partition;
+  const partitionTag = resource.extensions?.tags?.partitionExpose;
   if (typeof partitionTag === "string") {
     if (PARTITION_EXPOSE_OPTIONS.includes(partitionTag as PartitionExpose)) {
       return partitionTag as PartitionExpose;
     } else {
       throw new Error(
-        `"@partition ${partitionTag}" on resource '${resource.name}' not understood; must be one of: '${PARTITION_EXPOSE_OPTIONS.join("', '")}'`,
+        `"@partitionExpose ${partitionTag}" on resource '${resource.name}' not understood; must be one of: '${PARTITION_EXPOSE_OPTIONS.join("', '")}'`,
       );
     }
   } else if (partitionTag != null) {
     throw new Error(
-      `@partition on resource '${resource.name}' not understood; must be one of: '${PARTITION_EXPOSE_OPTIONS.join("', '")}'`,
+      `@partitionExpose on resource '${resource.name}' not understood; must be one of: '${PARTITION_EXPOSE_OPTIONS.join("', '")}'`,
     );
   } else {
     return null;

--- a/graphile-build/graphile-build-pg/src/plugins/PgTablesPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgTablesPlugin.ts
@@ -220,6 +220,13 @@ declare global {
       isUpdatable?: boolean;
       /** Checks capabilities of this resource to see if DELETE is even possible */
       isDeletable?: boolean;
+      /** Is this a partitioned table (i.e. doesn't store data locally) */
+      hasPartitions?: boolean;
+      /** If this table _is_ a partition, details of its parent */
+      partitionParent?: {
+        schemaName: string;
+        name: string;
+      };
     }
   }
 }

--- a/graphile-build/graphile-build-pg/src/plugins/PgTablesPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgTablesPlugin.ts
@@ -660,6 +660,9 @@ export const PgTablesPlugin: GraphileConfig.Plugin = {
           provides: ["default"],
           before: ["inferred", "override"],
           callback(behavior, resource) {
+            if (resource.extensions?.partitionParent) {
+              return [behavior, "-*"];
+            }
             const ext = resource.extensions;
             return [
               ...(ext?.isInsertable === false ? ["-resource:insert"] : []),

--- a/postgraphile/postgraphile/__tests__/kitchen-sink-data.sql
+++ b/postgraphile/postgraphile/__tests__/kitchen-sink-data.sql
@@ -74,6 +74,10 @@ delete from js_reserved.reserved cascade;
 
 delete from partitions.measurements cascade;
 delete from partitions.users cascade;
+delete from partitions.photos cascade;
+delete from partitions.locations cascade;
+delete from partitions.profiles cascade;
+delete from partitions.tags cascade;
 
 delete from d.post cascade;
 delete from d.person cascade;
@@ -921,6 +925,30 @@ insert into partitions.measurements
   ('2023-02-04T11:02:03Z', 'temp', '18.3', 1),
   ('2023-08-04T11:02:03Z', 'temp', '39.2', 3),
   ('2023-08-04T11:02:03Z', 'humidity', '100', 2);
+
+insert into partitions.photos (id) values 
+  ('28be1007-e624-46c8-bfa0-6b7e5a2c630e'),
+  ('36a9cc35-f158-4648-83f4-d8fa04ee7527');
+insert into partitions.locations (id) values 
+  ('039b863d-73c6-44f7-bef3-2e0058a85552'),
+  ('4b7c1188-94e9-4ae1-849c-e088964a9911');
+insert into partitions.profiles (id) values 
+  ('8cc170ed-7869-4cd9-ae4b-8d3b528de606'),
+  ('e3f89f32-e963-425e-b08f-a4c6be2161b6');
+insert into partitions.tags (entity_kind, entity_id, tag) values 
+  ('photos', '28be1007-e624-46c8-bfa0-6b7e5a2c630e', 'sunny'),
+  ('photos', '28be1007-e624-46c8-bfa0-6b7e5a2c630e', 'beach'),
+  ('photos', '28be1007-e624-46c8-bfa0-6b7e5a2c630e', 'spf50'),
+  ('photos', '28be1007-e624-46c8-bfa0-6b7e5a2c630e', 'holiday'),
+  ('photos', '36a9cc35-f158-4648-83f4-d8fa04ee7527', 'yummy'),
+  ('photos', '36a9cc35-f158-4648-83f4-d8fa04ee7527', 'sundae'),
+  ('photos', '36a9cc35-f158-4648-83f4-d8fa04ee7527', 'dessert'),
+  ('locations', '039b863d-73c6-44f7-bef3-2e0058a85552', 'canal'),
+  ('locations', '039b863d-73c6-44f7-bef3-2e0058a85552', 'boats'),
+  ('locations', '4b7c1188-94e9-4ae1-849c-e088964a9911', 'mountain'),
+  ('profiles', '8cc170ed-7869-4cd9-ae4b-8d3b528de606', 'admin'),
+  ('profiles', 'e3f89f32-e963-425e-b08f-a4c6be2161b6', 'moderator');
+
 
 insert into nested_arrays.t
   (k, v) values

--- a/postgraphile/postgraphile/__tests__/kitchen-sink-schema.sql
+++ b/postgraphile/postgraphile/__tests__/kitchen-sink-schema.sql
@@ -1913,6 +1913,70 @@ create table partitions.measurements_y2022 partition of partitions.measurements 
 create table partitions.measurements_y2023 partition of partitions.measurements for values from ('2023-01-01T00:00:00Z') to ('2024-01-01T00:00:00Z');
 create table partitions.measurements_y2024 partition of partitions.measurements for values from ('2024-01-01T00:00:00Z') to ('2025-01-01T00:00:00Z');
 
+-- More partitions, this time where we want to see the subtables and not the supertable
+
+create table partitions.entity_kinds (kind text primary key);
+comment on table partitions.entity_kinds is '@enum';
+insert into partitions.entity_kinds (kind) values ('photos'), ('locations'), ('profiles');
+
+create table partitions.photos (
+  id uuid primary key
+);
+create table partitions.locations (
+  id uuid primary key
+);
+create table partitions.profiles (
+  id uuid primary key
+);
+
+create table partitions.tags (
+  entity_kind text    not null references partitions.entity_kinds(kind),
+  entity_id   uuid    not null,
+  tag         citext  not null,
+  primary key (entity_kind, entity_id, tag)
+) partition by list (entity_kind);
+
+create table partitions.photo_tags
+  partition of partitions.tags for values in ('photos');
+alter table partitions.photo_tags
+  add constraint photo_tags_entity_fk
+  foreign key (entity_id) references partitions.photos(id) on delete cascade;
+
+create table partitions.location_tags
+  partition of partitions.tags for values in ('locations');
+alter table partitions.location_tags
+  add constraint location_tags_entity_fk
+  foreign key (entity_id) references partitions.locations(id) on delete cascade;
+
+create table partitions.profile_tags
+  partition of partitions.tags for values in ('profiles');
+alter table partitions.profile_tags
+  add constraint profile_tags_entity_fk
+  foreign key (entity_id) references partitions.profiles(id) on delete cascade;
+
+insert into partitions.photos (id) values 
+  ('28be1007-e624-46c8-bfa0-6b7e5a2c630e'),
+  ('36a9cc35-f158-4648-83f4-d8fa04ee7527');
+insert into partitions.locations (id) values 
+  ('039b863d-73c6-44f7-bef3-2e0058a85552'),
+  ('4b7c1188-94e9-4ae1-849c-e088964a9911');
+insert into partitions.profiles (id) values 
+  ('8cc170ed-7869-4cd9-ae4b-8d3b528de606'),
+  ('e3f89f32-e963-425e-b08f-a4c6be2161b6');
+insert into partitions.tags (entity_kind, entity_id, tag) values 
+  ('photos', '28be1007-e624-46c8-bfa0-6b7e5a2c630e', 'sunny'),
+  ('photos', '28be1007-e624-46c8-bfa0-6b7e5a2c630e', 'beach'),
+  ('photos', '28be1007-e624-46c8-bfa0-6b7e5a2c630e', 'spf50'),
+  ('photos', '28be1007-e624-46c8-bfa0-6b7e5a2c630e', 'holiday'),
+  ('photos', '36a9cc35-f158-4648-83f4-d8fa04ee7527', 'yummy'),
+  ('photos', '36a9cc35-f158-4648-83f4-d8fa04ee7527', 'sundae'),
+  ('photos', '36a9cc35-f158-4648-83f4-d8fa04ee7527', 'dessert'),
+  ('locations', '039b863d-73c6-44f7-bef3-2e0058a85552', 'canal'),
+  ('locations', '039b863d-73c6-44f7-bef3-2e0058a85552', 'boats'),
+  ('locations', '4b7c1188-94e9-4ae1-849c-e088964a9911', 'mountain'),
+  ('profiles', '8cc170ed-7869-4cd9-ae4b-8d3b528de606', 'admin'),
+  ('profiles', 'e3f89f32-e963-425e-b08f-a4c6be2161b6', 'moderator');
+
 --------------------------------------------------------------------------------
 
 create schema nested_arrays;

--- a/postgraphile/postgraphile/__tests__/kitchen-sink-schema.sql
+++ b/postgraphile/postgraphile/__tests__/kitchen-sink-schema.sql
@@ -1936,6 +1936,8 @@ create table partitions.tags (
   primary key (entity_kind, entity_id, tag)
 ) partition by list (entity_kind);
 
+comment on table partitions.tags is '@partitionExpose child';
+
 create table partitions.photo_tags
   partition of partitions.tags for values in ('photos');
 alter table partitions.photo_tags

--- a/postgraphile/postgraphile/__tests__/kitchen-sink-schema.sql
+++ b/postgraphile/postgraphile/__tests__/kitchen-sink-schema.sql
@@ -1917,7 +1917,8 @@ create table partitions.measurements_y2024 partition of partitions.measurements 
 
 create table partitions.entity_kinds (kind text primary key);
 comment on table partitions.entity_kinds is '@enum';
-insert into partitions.entity_kinds (kind) values ('photos'), ('locations'), ('profiles');
+insert into partitions.entity_kinds (kind)
+  values ('photos'), ('locations'), ('profiles');
 
 create table partitions.photos (
   id uuid primary key
@@ -1955,29 +1956,6 @@ create table partitions.profile_tags
 alter table partitions.profile_tags
   add constraint profile_tags_entity_fk
   foreign key (entity_id) references partitions.profiles(id) on delete cascade;
-
-insert into partitions.photos (id) values 
-  ('28be1007-e624-46c8-bfa0-6b7e5a2c630e'),
-  ('36a9cc35-f158-4648-83f4-d8fa04ee7527');
-insert into partitions.locations (id) values 
-  ('039b863d-73c6-44f7-bef3-2e0058a85552'),
-  ('4b7c1188-94e9-4ae1-849c-e088964a9911');
-insert into partitions.profiles (id) values 
-  ('8cc170ed-7869-4cd9-ae4b-8d3b528de606'),
-  ('e3f89f32-e963-425e-b08f-a4c6be2161b6');
-insert into partitions.tags (entity_kind, entity_id, tag) values 
-  ('photos', '28be1007-e624-46c8-bfa0-6b7e5a2c630e', 'sunny'),
-  ('photos', '28be1007-e624-46c8-bfa0-6b7e5a2c630e', 'beach'),
-  ('photos', '28be1007-e624-46c8-bfa0-6b7e5a2c630e', 'spf50'),
-  ('photos', '28be1007-e624-46c8-bfa0-6b7e5a2c630e', 'holiday'),
-  ('photos', '36a9cc35-f158-4648-83f4-d8fa04ee7527', 'yummy'),
-  ('photos', '36a9cc35-f158-4648-83f4-d8fa04ee7527', 'sundae'),
-  ('photos', '36a9cc35-f158-4648-83f4-d8fa04ee7527', 'dessert'),
-  ('locations', '039b863d-73c6-44f7-bef3-2e0058a85552', 'canal'),
-  ('locations', '039b863d-73c6-44f7-bef3-2e0058a85552', 'boats'),
-  ('locations', '4b7c1188-94e9-4ae1-849c-e088964a9911', 'mountain'),
-  ('profiles', '8cc170ed-7869-4cd9-ae4b-8d3b528de606', 'admin'),
-  ('profiles', 'e3f89f32-e963-425e-b08f-a4c6be2161b6', 'moderator');
 
 --------------------------------------------------------------------------------
 

--- a/postgraphile/postgraphile/__tests__/queries/v4/partitions.json5
+++ b/postgraphile/postgraphile/__tests__/queries/v4/partitions.json5
@@ -70,4 +70,232 @@
       hasPreviousPage: false,
     },
   },
+  allLocationTags: {
+    nodes: [
+      {
+        nodeId: "WyJsb2NhdGlvbl90YWdzIiwibG9jYXRpb25zIiwiMDM5Yjg2M2QtNzNjNi00NGY3LWJlZjMtMmUwMDU4YTg1NTUyIiwiYm9hdHMiXQ==",
+        entityId: "<UUID 1>",
+        entityKind: "LOCATIONS",
+        tag: "boats",
+        locationByEntityId: {
+          nodeId: "WyJsb2NhdGlvbnMiLCIwMzliODYzZC03M2M2LTQ0ZjctYmVmMy0yZTAwNThhODU1NTIiXQ==",
+          id: "<UUID 1>",
+        },
+      },
+      {
+        nodeId: "WyJsb2NhdGlvbl90YWdzIiwibG9jYXRpb25zIiwiMDM5Yjg2M2QtNzNjNi00NGY3LWJlZjMtMmUwMDU4YTg1NTUyIiwiY2FuYWwiXQ==",
+        entityId: "<UUID 1>",
+        entityKind: "LOCATIONS",
+        tag: "canal",
+        locationByEntityId: {
+          nodeId: "WyJsb2NhdGlvbnMiLCIwMzliODYzZC03M2M2LTQ0ZjctYmVmMy0yZTAwNThhODU1NTIiXQ==",
+          id: "<UUID 1>",
+        },
+      },
+      {
+        nodeId: "WyJsb2NhdGlvbl90YWdzIiwibG9jYXRpb25zIiwiNGI3YzExODgtOTRlOS00YWUxLTg0OWMtZTA4ODk2NGE5OTExIiwibW91bnRhaW4iXQ==",
+        entityId: "<UUID 2>",
+        entityKind: "LOCATIONS",
+        tag: "mountain",
+        locationByEntityId: {
+          nodeId: "WyJsb2NhdGlvbnMiLCI0YjdjMTE4OC05NGU5LTRhZTEtODQ5Yy1lMDg4OTY0YTk5MTEiXQ==",
+          id: "<UUID 2>",
+        },
+      },
+    ],
+  },
+  allLocations: {
+    nodes: [
+      {
+        nodeId: "WyJsb2NhdGlvbnMiLCIwMzliODYzZC03M2M2LTQ0ZjctYmVmMy0yZTAwNThhODU1NTIiXQ==",
+        id: "<UUID 1>",
+        locationTagsByEntityId: {
+          nodes: [
+            {
+              tag: "boats",
+            },
+            {
+              tag: "canal",
+            },
+          ],
+        },
+      },
+      {
+        nodeId: "WyJsb2NhdGlvbnMiLCI0YjdjMTE4OC05NGU5LTRhZTEtODQ5Yy1lMDg4OTY0YTk5MTEiXQ==",
+        id: "<UUID 2>",
+        locationTagsByEntityId: {
+          nodes: [
+            {
+              tag: "mountain",
+            },
+          ],
+        },
+      },
+    ],
+  },
+  allPhotoTags: {
+    nodes: [
+      {
+        nodeId: "WyJwaG90b190YWdzIiwicGhvdG9zIiwiMjhiZTEwMDctZTYyNC00NmM4LWJmYTAtNmI3ZTVhMmM2MzBlIiwiYmVhY2giXQ==",
+        entityId: "<UUID 3>",
+        entityKind: "PHOTOS",
+        tag: "beach",
+        photoByEntityId: {
+          nodeId: "WyJwaG90b3MiLCIyOGJlMTAwNy1lNjI0LTQ2YzgtYmZhMC02YjdlNWEyYzYzMGUiXQ==",
+          id: "<UUID 3>",
+        },
+      },
+      {
+        nodeId: "WyJwaG90b190YWdzIiwicGhvdG9zIiwiMjhiZTEwMDctZTYyNC00NmM4LWJmYTAtNmI3ZTVhMmM2MzBlIiwiaG9saWRheSJd",
+        entityId: "<UUID 3>",
+        entityKind: "PHOTOS",
+        tag: "holiday",
+        photoByEntityId: {
+          nodeId: "WyJwaG90b3MiLCIyOGJlMTAwNy1lNjI0LTQ2YzgtYmZhMC02YjdlNWEyYzYzMGUiXQ==",
+          id: "<UUID 3>",
+        },
+      },
+      {
+        nodeId: "WyJwaG90b190YWdzIiwicGhvdG9zIiwiMjhiZTEwMDctZTYyNC00NmM4LWJmYTAtNmI3ZTVhMmM2MzBlIiwic3BmNTAiXQ==",
+        entityId: "<UUID 3>",
+        entityKind: "PHOTOS",
+        tag: "spf50",
+        photoByEntityId: {
+          nodeId: "WyJwaG90b3MiLCIyOGJlMTAwNy1lNjI0LTQ2YzgtYmZhMC02YjdlNWEyYzYzMGUiXQ==",
+          id: "<UUID 3>",
+        },
+      },
+      {
+        nodeId: "WyJwaG90b190YWdzIiwicGhvdG9zIiwiMjhiZTEwMDctZTYyNC00NmM4LWJmYTAtNmI3ZTVhMmM2MzBlIiwic3VubnkiXQ==",
+        entityId: "<UUID 3>",
+        entityKind: "PHOTOS",
+        tag: "sunny",
+        photoByEntityId: {
+          nodeId: "WyJwaG90b3MiLCIyOGJlMTAwNy1lNjI0LTQ2YzgtYmZhMC02YjdlNWEyYzYzMGUiXQ==",
+          id: "<UUID 3>",
+        },
+      },
+      {
+        nodeId: "WyJwaG90b190YWdzIiwicGhvdG9zIiwiMzZhOWNjMzUtZjE1OC00NjQ4LTgzZjQtZDhmYTA0ZWU3NTI3IiwiZGVzc2VydCJd",
+        entityId: "<UUID 4>",
+        entityKind: "PHOTOS",
+        tag: "dessert",
+        photoByEntityId: {
+          nodeId: "WyJwaG90b3MiLCIzNmE5Y2MzNS1mMTU4LTQ2NDgtODNmNC1kOGZhMDRlZTc1MjciXQ==",
+          id: "<UUID 4>",
+        },
+      },
+      {
+        nodeId: "WyJwaG90b190YWdzIiwicGhvdG9zIiwiMzZhOWNjMzUtZjE1OC00NjQ4LTgzZjQtZDhmYTA0ZWU3NTI3Iiwic3VuZGFlIl0=",
+        entityId: "<UUID 4>",
+        entityKind: "PHOTOS",
+        tag: "sundae",
+        photoByEntityId: {
+          nodeId: "WyJwaG90b3MiLCIzNmE5Y2MzNS1mMTU4LTQ2NDgtODNmNC1kOGZhMDRlZTc1MjciXQ==",
+          id: "<UUID 4>",
+        },
+      },
+      {
+        nodeId: "WyJwaG90b190YWdzIiwicGhvdG9zIiwiMzZhOWNjMzUtZjE1OC00NjQ4LTgzZjQtZDhmYTA0ZWU3NTI3IiwieXVtbXkiXQ==",
+        entityId: "<UUID 4>",
+        entityKind: "PHOTOS",
+        tag: "yummy",
+        photoByEntityId: {
+          nodeId: "WyJwaG90b3MiLCIzNmE5Y2MzNS1mMTU4LTQ2NDgtODNmNC1kOGZhMDRlZTc1MjciXQ==",
+          id: "<UUID 4>",
+        },
+      },
+    ],
+  },
+  allPhotos: {
+    nodes: [
+      {
+        nodeId: "WyJwaG90b3MiLCIyOGJlMTAwNy1lNjI0LTQ2YzgtYmZhMC02YjdlNWEyYzYzMGUiXQ==",
+        id: "<UUID 3>",
+        photoTagsByEntityId: {
+          nodes: [
+            {
+              tag: "beach",
+            },
+            {
+              tag: "holiday",
+            },
+            {
+              tag: "spf50",
+            },
+            {
+              tag: "sunny",
+            },
+          ],
+        },
+      },
+      {
+        nodeId: "WyJwaG90b3MiLCIzNmE5Y2MzNS1mMTU4LTQ2NDgtODNmNC1kOGZhMDRlZTc1MjciXQ==",
+        id: "<UUID 4>",
+        photoTagsByEntityId: {
+          nodes: [
+            {
+              tag: "dessert",
+            },
+            {
+              tag: "sundae",
+            },
+            {
+              tag: "yummy",
+            },
+          ],
+        },
+      },
+    ],
+  },
+  allProfileTags: {
+    nodes: [
+      {
+        nodeId: "WyJwcm9maWxlX3RhZ3MiLCJwcm9maWxlcyIsIjhjYzE3MGVkLTc4NjktNGNkOS1hZTRiLThkM2I1MjhkZTYwNiIsImFkbWluIl0=",
+        entityId: "<UUID 5>",
+        entityKind: "PROFILES",
+        tag: "admin",
+        profileByEntityId: {
+          nodeId: "WyJwcm9maWxlcyIsIjhjYzE3MGVkLTc4NjktNGNkOS1hZTRiLThkM2I1MjhkZTYwNiJd",
+          id: "<UUID 5>",
+        },
+      },
+      {
+        nodeId: "WyJwcm9maWxlX3RhZ3MiLCJwcm9maWxlcyIsImUzZjg5ZjMyLWU5NjMtNDI1ZS1iMDhmLWE0YzZiZTIxNjFiNiIsIm1vZGVyYXRvciJd",
+        entityId: "<UUID 6>",
+        entityKind: "PROFILES",
+        tag: "moderator",
+        profileByEntityId: {
+          nodeId: "WyJwcm9maWxlcyIsImUzZjg5ZjMyLWU5NjMtNDI1ZS1iMDhmLWE0YzZiZTIxNjFiNiJd",
+          id: "<UUID 6>",
+        },
+      },
+    ],
+  },
+  allProfiles: {
+    nodes: [
+      {
+        nodeId: "WyJwcm9maWxlcyIsIjhjYzE3MGVkLTc4NjktNGNkOS1hZTRiLThkM2I1MjhkZTYwNiJd",
+        id: "<UUID 5>",
+        profileTagsByEntityId: {
+          nodes: [
+            {
+              tag: "admin",
+            },
+          ],
+        },
+      },
+      {
+        nodeId: "WyJwcm9maWxlcyIsImUzZjg5ZjMyLWU5NjMtNDI1ZS1iMDhmLWE0YzZiZTIxNjFiNiJd",
+        id: "<UUID 6>",
+        profileTagsByEntityId: {
+          nodes: [
+            {
+              tag: "moderator",
+            },
+          ],
+        },
+      },
+    ],
+  },
 }

--- a/postgraphile/postgraphile/__tests__/queries/v4/partitions.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/partitions.mermaid
@@ -8,89 +8,407 @@ graph TD
     classDef bucket fill:#f6f6f6,color:#000,stroke-width:2px,text-align:left
 
     subgraph "Buckets for queries/v4/partitions"
-    Bucket0("Bucket 0 (root)<br /><br />1: PgSelectInlineApply[48]<br />ᐳ: Access[9], Access[10], Object[11]<br />2: PgSelect[8], PgSelect[17]<br />ᐳ: Access[26], Access[49]<br />3: Connection[12], PgSelectRows[19]<br />ᐳ: 18, 20, 21<br />4: ConnectionItems[14]<br />ᐳ: 25, 27, 28, 29"):::bucket
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 26, 14, 49, 21, 27, 29<br /><br />ROOT Connectionᐸ8ᐳ[12]"):::bucket
-    Bucket3("Bucket 3 (listItem)<br />Deps: 26, 49<br /><br />ROOT __Item{3}ᐸ14ᐳ[23]"):::bucket
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 23, 24, 49, 33<br /><br />ROOT Edge{3}[24]"):::bucket
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 34, 49<br /><br />ROOT PgSelectSingle{4}ᐸmeasurementsᐳ[34]<br />1: <br />ᐳ: 35, 36, 37, 50, 51<br />2: PgSelectRows[44]<br />ᐳ: First[43], PgSelectSingle[45]"):::bucket
-    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 45<br /><br />ROOT PgSelectSingle{5}ᐸusersᐳ[45]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: 207, 211, 215, 219, 223, 227, 231<br />ᐳ: 9, 10, 94, 100, 104, 110, 114, 120, 11<br />2: 8, 15, 20, 25, 30, 35, 40, 65<br />ᐳ: 86, 208, 212, 216, 220, 224, 228, 232<br />3: 12, 17, 22, 27, 32, 37, 42, 67<br />ᐳ: 66, 68, 69<br />4: 44, 47, 50, 53, 56, 59, 62<br />ᐳ: 85, 87, 88, 89"):::bucket
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 86, 44, 208, 69, 87, 89<br /><br />ROOT Connectionᐸ8ᐳ[12]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 17, 47, 94, 212, 100<br /><br />ROOT Connectionᐸ15ᐳ[17]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 22, 50, 100, 216<br /><br />ROOT Connectionᐸ20ᐳ[22]"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 27, 53, 104, 220, 110<br /><br />ROOT Connectionᐸ25ᐳ[27]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 32, 56, 110, 224<br /><br />ROOT Connectionᐸ30ᐳ[32]"):::bucket
+    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 37, 59, 114, 228, 120<br /><br />ROOT Connectionᐸ35ᐳ[37]"):::bucket
+    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 42, 62, 120, 232<br /><br />ROOT Connectionᐸ40ᐳ[42]"):::bucket
+    Bucket15("Bucket 15 (listItem)<br />Deps: 86, 208<br /><br />ROOT __Item{15}ᐸ44ᐳ[71]"):::bucket
+    Bucket16("Bucket 16 (listItem)<br />Deps: 94, 212, 100<br /><br />ROOT __Item{16}ᐸ47ᐳ[73]"):::bucket
+    Bucket17("Bucket 17 (listItem)<br />Deps: 100, 216<br /><br />ROOT __Item{17}ᐸ50ᐳ[75]"):::bucket
+    Bucket18("Bucket 18 (listItem)<br />Deps: 104, 220, 110<br /><br />ROOT __Item{18}ᐸ53ᐳ[77]"):::bucket
+    Bucket19("Bucket 19 (listItem)<br />Deps: 110, 224<br /><br />ROOT __Item{19}ᐸ56ᐳ[79]"):::bucket
+    Bucket20("Bucket 20 (listItem)<br />Deps: 114, 228, 120<br /><br />ROOT __Item{20}ᐸ59ᐳ[81]"):::bucket
+    Bucket21("Bucket 21 (listItem)<br />Deps: 120, 232<br /><br />ROOT __Item{21}ᐸ62ᐳ[83]"):::bucket
+    Bucket22("Bucket 22 (nullableBoundary)<br />Deps: 71, 72, 208, 93<br /><br />ROOT Edge{15}[72]"):::bucket
+    Bucket23("Bucket 23 (nullableBoundary)<br />Deps: 74, 94, 212, 100<br /><br />ROOT PgSelectSingle{16}ᐸlocation_tagsᐳ[74]<br />1: <br />ᐳ: 95, 96, 97, 213, 98, 99, 214<br />2: PgSelectRows[151]<br />ᐳ: First[150], PgSelectSingle[152]"):::bucket
+    Bucket24("Bucket 24 (nullableBoundary)<br />Deps: 76, 100, 216, 75<br /><br />ROOT PgSelectSingle{17}ᐸlocationsᐳ[76]<br />1: <br />ᐳ: 101, 217, 102, 103, 218<br />2: Connection[132]<br />3: ConnectionItems[168]"):::bucket
+    Bucket25("Bucket 25 (nullableBoundary)<br />Deps: 78, 104, 220, 110<br /><br />ROOT PgSelectSingle{18}ᐸphoto_tagsᐳ[78]<br />1: <br />ᐳ: 105, 106, 107, 221, 108, 109, 222<br />2: PgSelectRows[158]<br />ᐳ: First[157], PgSelectSingle[159]"):::bucket
+    Bucket26("Bucket 26 (nullableBoundary)<br />Deps: 80, 110, 224, 79<br /><br />ROOT PgSelectSingle{19}ᐸphotosᐳ[80]<br />1: <br />ᐳ: 111, 225, 112, 113, 226<br />2: Connection[138]<br />3: ConnectionItems[171]"):::bucket
+    Bucket27("Bucket 27 (nullableBoundary)<br />Deps: 82, 114, 228, 120<br /><br />ROOT PgSelectSingle{20}ᐸprofile_tagsᐳ[82]<br />1: <br />ᐳ: 115, 116, 117, 229, 118, 119, 230<br />2: PgSelectRows[165]<br />ᐳ: First[164], PgSelectSingle[166]"):::bucket
+    Bucket28("Bucket 28 (nullableBoundary)<br />Deps: 84, 120, 232, 83<br /><br />ROOT PgSelectSingle{21}ᐸprofilesᐳ[84]<br />1: <br />ᐳ: 121, 233, 122, 123, 234<br />2: Connection[144]<br />3: ConnectionItems[174]"):::bucket
+    Bucket29("Bucket 29 (nullableBoundary)<br />Deps: 124, 208<br /><br />ROOT PgSelectSingle{22}ᐸmeasurementsᐳ[124]<br />1: <br />ᐳ: 167, 186, 187, 209, 210<br />2: PgSelectRows[194]<br />ᐳ: First[193], PgSelectSingle[195]"):::bucket
+    Bucket30("Bucket 30 (nullableBoundary)<br />Deps: 152, 100<br /><br />ROOT PgSelectSingle{23}ᐸlocationsᐳ[152]"):::bucket
+    Bucket31("Bucket 31 (nullableBoundary)<br />Deps: 159, 110<br /><br />ROOT PgSelectSingle{25}ᐸphotosᐳ[159]"):::bucket
+    Bucket32("Bucket 32 (nullableBoundary)<br />Deps: 166, 120<br /><br />ROOT PgSelectSingle{27}ᐸprofilesᐳ[166]"):::bucket
+    Bucket36("Bucket 36 (nullableBoundary)<br />Deps: 195<br /><br />ROOT PgSelectSingle{29}ᐸusersᐳ[195]"):::bucket
+    Bucket37("Bucket 37 (listItem)<br /><br />ROOT __Item{37}ᐸ168ᐳ[196]"):::bucket
+    Bucket38("Bucket 38 (listItem)<br /><br />ROOT __Item{38}ᐸ171ᐳ[198]"):::bucket
+    Bucket39("Bucket 39 (listItem)<br /><br />ROOT __Item{39}ᐸ174ᐳ[200]"):::bucket
+    Bucket40("Bucket 40 (nullableBoundary)<br />Deps: 197<br /><br />ROOT PgSelectSingle{37}ᐸlocation_tagsᐳ[197]"):::bucket
+    Bucket41("Bucket 41 (nullableBoundary)<br />Deps: 199<br /><br />ROOT PgSelectSingle{38}ᐸphoto_tagsᐳ[199]"):::bucket
+    Bucket42("Bucket 42 (nullableBoundary)<br />Deps: 201<br /><br />ROOT PgSelectSingle{39}ᐸprofile_tagsᐳ[201]"):::bucket
     end
-    Bucket0 --> Bucket1
-    Bucket1 --> Bucket3
-    Bucket3 --> Bucket4
-    Bucket4 --> Bucket5
-    Bucket5 --> Bucket6
+    Bucket0 --> Bucket1 & Bucket2 & Bucket3 & Bucket4 & Bucket5 & Bucket6 & Bucket7
+    Bucket1 --> Bucket15
+    Bucket2 --> Bucket16
+    Bucket3 --> Bucket17
+    Bucket4 --> Bucket18
+    Bucket5 --> Bucket19
+    Bucket6 --> Bucket20
+    Bucket7 --> Bucket21
+    Bucket15 --> Bucket22
+    Bucket16 --> Bucket23
+    Bucket17 --> Bucket24
+    Bucket18 --> Bucket25
+    Bucket19 --> Bucket26
+    Bucket20 --> Bucket27
+    Bucket21 --> Bucket28
+    Bucket22 --> Bucket29
+    Bucket23 --> Bucket30
+    Bucket24 --> Bucket37
+    Bucket25 --> Bucket31
+    Bucket26 --> Bucket38
+    Bucket27 --> Bucket32
+    Bucket28 --> Bucket39
+    Bucket29 --> Bucket36
+    Bucket37 --> Bucket40
+    Bucket38 --> Bucket41
+    Bucket39 --> Bucket42
 
     %% plan dependencies
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸmeasurements+1ᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    PgSelectInlineApply48["PgSelectInlineApply[48∈0] ➊"]:::plan
-    Object11 & PgSelectInlineApply48 --> PgSelect8
+    PgSelectInlineApply207["PgSelectInlineApply[207∈0] ➊"]:::plan
+    Object11 & PgSelectInlineApply207 --> PgSelect8
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
+    PgSelect15[["PgSelect[15∈0] ➊<br />ᐸlocation_tagsᐳ"]]:::plan
+    PgSelectInlineApply211["PgSelectInlineApply[211∈0] ➊"]:::plan
+    Object11 & PgSelectInlineApply211 --> PgSelect15
+    PgSelect20[["PgSelect[20∈0] ➊<br />ᐸlocationsᐳ"]]:::plan
+    PgSelectInlineApply215["PgSelectInlineApply[215∈0] ➊"]:::plan
+    Object11 & PgSelectInlineApply215 --> PgSelect20
+    PgSelect25[["PgSelect[25∈0] ➊<br />ᐸphoto_tagsᐳ"]]:::plan
+    PgSelectInlineApply219["PgSelectInlineApply[219∈0] ➊"]:::plan
+    Object11 & PgSelectInlineApply219 --> PgSelect25
+    PgSelect30[["PgSelect[30∈0] ➊<br />ᐸphotosᐳ"]]:::plan
+    PgSelectInlineApply223["PgSelectInlineApply[223∈0] ➊"]:::plan
+    Object11 & PgSelectInlineApply223 --> PgSelect30
+    PgSelect35[["PgSelect[35∈0] ➊<br />ᐸprofile_tagsᐳ"]]:::plan
+    PgSelectInlineApply227["PgSelectInlineApply[227∈0] ➊"]:::plan
+    Object11 & PgSelectInlineApply227 --> PgSelect35
+    PgSelect40[["PgSelect[40∈0] ➊<br />ᐸprofilesᐳ"]]:::plan
+    PgSelectInlineApply231["PgSelectInlineApply[231∈0] ➊"]:::plan
+    Object11 & PgSelectInlineApply231 --> PgSelect40
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
     Connection12[["Connection[12∈0] ➊<br />ᐸ8ᐳ<br />Dependents: 4"]]:::plan
     PgSelect8 --> Connection12
-    ConnectionItems14[["ConnectionItems[14∈0] ➊<br />Dependents: 3<br />More deps:<br />- Connection[12]"]]:::plan
-    PgSelect17[["PgSelect[17∈0] ➊<br />ᐸmeasurements(aggregate)ᐳ"]]:::plan
-    Object11 --> PgSelect17
-    First18{{"First[18∈0] ➊"}}:::plan
-    PgSelectRows19[["PgSelectRows[19∈0] ➊"]]:::plan
-    PgSelectRows19 --> First18
-    PgSelect17 --> PgSelectRows19
-    PgSelectSingle20{{"PgSelectSingle[20∈0] ➊<br />ᐸmeasurementsᐳ"}}:::plan
-    First18 --> PgSelectSingle20
-    First25{{"First[25∈0] ➊<br />More deps:<br />- ConnectionItems[14]"}}:::plan
-    Access26{{"Access[26∈0] ➊<br />ᐸ8.cursorDetailsᐳ<br />Dependents: 3"}}:::plan
-    PgSelect8 --> Access26
-    Last28{{"Last[28∈0] ➊<br />More deps:<br />- ConnectionItems[14]"}}:::plan
-    Access49{{"Access[49∈0] ➊<br />ᐸ8.m.joinDetailsFor39ᐳ"}}:::plan
-    PgSelect8 --> Access49
-    PageInfo22{{"PageInfo[22∈1] ➊<br />More deps:<br />- Connection[12]"}}:::plan
-    Access30{{"Access[30∈1] ➊<br />ᐸ12.hasNextPageᐳ<br />More deps:<br />- Connection[12]"}}:::plan
-    Access31{{"Access[31∈1] ➊<br />ᐸ12.hasPreviousPageᐳ<br />More deps:<br />- Connection[12]"}}:::plan
-    Edge24{{"Edge[24∈3]"}}:::plan
-    __Item23[/"__Item[23∈3]<br />ᐸ14ᐳ<br />More deps:<br />- ConnectionItems[14]"\]:::itemplan
-    PgCursor33{{"PgCursor[33∈3]<br />More deps:<br />- Access[26]"}}:::plan
-    __Item23 & PgCursor33 --> Edge24
-    __Item23 --> PgCursor33
-    PgSelectSingle34{{"PgSelectSingle[34∈4]<br />ᐸmeasurementsᐳ"}}:::plan
-    __Item23 --> PgSelectSingle34
-    List50{{"List[50∈5]<br />ᐸ49,34ᐳ"}}:::plan
-    Access49 & PgSelectSingle34 --> List50
-    PgClassExpression35{{"PgClassExpression[35∈5]<br />ᐸ__measurem...timestamp”ᐳ"}}:::plan
-    PgSelectSingle34 --> PgClassExpression35
-    PgClassExpression36{{"PgClassExpression[36∈5]<br />ᐸ__measurements__.”key”ᐳ"}}:::plan
-    PgClassExpression35 o--o PgClassExpression36
-    PgClassExpression37{{"PgClassExpression[37∈5]<br />ᐸ__measurem...__.”value”ᐳ"}}:::plan
-    PgClassExpression36 o--o PgClassExpression37
-    First43{{"First[43∈5]"}}:::plan
-    PgSelectRows44[["PgSelectRows[44∈5]"]]:::plan
-    PgSelectRows44 --> First43
-    Lambda51{{"Lambda[51∈5]<br />ᐸpgInlineViaJoinTransformᐳ"}}:::plan
-    Lambda51 --> PgSelectRows44
-    PgSelectSingle45{{"PgSelectSingle[45∈5]<br />ᐸusersᐳ"}}:::plan
-    First43 --> PgSelectSingle45
-    List50 --> Lambda51
-    PgClassExpression46{{"PgClassExpression[46∈6]<br />ᐸ__users__.”id”ᐳ"}}:::plan
-    PgSelectSingle45 --> PgClassExpression46
-    PgClassExpression47{{"PgClassExpression[47∈6]<br />ᐸ__users__.”name”ᐳ"}}:::plan
-    PgClassExpression46 o--o PgClassExpression47
+    Connection17[["Connection[17∈0] ➊<br />ᐸ15ᐳ"]]:::plan
+    PgSelect15 --> Connection17
+    Connection22[["Connection[22∈0] ➊<br />ᐸ20ᐳ"]]:::plan
+    PgSelect20 --> Connection22
+    Connection27[["Connection[27∈0] ➊<br />ᐸ25ᐳ"]]:::plan
+    PgSelect25 --> Connection27
+    Connection32[["Connection[32∈0] ➊<br />ᐸ30ᐳ"]]:::plan
+    PgSelect30 --> Connection32
+    Connection37[["Connection[37∈0] ➊<br />ᐸ35ᐳ"]]:::plan
+    PgSelect35 --> Connection37
+    Connection42[["Connection[42∈0] ➊<br />ᐸ40ᐳ"]]:::plan
+    PgSelect40 --> Connection42
+    ConnectionItems44[["ConnectionItems[44∈0] ➊<br />Dependents: 3<br />More deps:<br />- Connection[12]"]]:::plan
+    ConnectionItems47[["ConnectionItems[47∈0] ➊"]]:::plan
+    Connection17 --> ConnectionItems47
+    ConnectionItems50[["ConnectionItems[50∈0] ➊"]]:::plan
+    Connection22 --> ConnectionItems50
+    ConnectionItems53[["ConnectionItems[53∈0] ➊"]]:::plan
+    Connection27 --> ConnectionItems53
+    ConnectionItems56[["ConnectionItems[56∈0] ➊"]]:::plan
+    Connection32 --> ConnectionItems56
+    ConnectionItems59[["ConnectionItems[59∈0] ➊"]]:::plan
+    Connection37 --> ConnectionItems59
+    ConnectionItems62[["ConnectionItems[62∈0] ➊"]]:::plan
+    Connection42 --> ConnectionItems62
+    PgSelect65[["PgSelect[65∈0] ➊<br />ᐸmeasurements(aggregate)ᐳ"]]:::plan
+    Object11 --> PgSelect65
+    First66{{"First[66∈0] ➊"}}:::plan
+    PgSelectRows67[["PgSelectRows[67∈0] ➊"]]:::plan
+    PgSelectRows67 --> First66
+    PgSelect65 --> PgSelectRows67
+    PgSelectSingle68{{"PgSelectSingle[68∈0] ➊<br />ᐸmeasurementsᐳ"}}:::plan
+    First66 --> PgSelectSingle68
+    First85{{"First[85∈0] ➊<br />More deps:<br />- ConnectionItems[44]"}}:::plan
+    Access86{{"Access[86∈0] ➊<br />ᐸ8.cursorDetailsᐳ<br />Dependents: 3"}}:::plan
+    PgSelect8 --> Access86
+    Last88{{"Last[88∈0] ➊<br />More deps:<br />- ConnectionItems[44]"}}:::plan
+    Access208{{"Access[208∈0] ➊<br />ᐸ8.m.joinDetailsFor189ᐳ"}}:::plan
+    PgSelect8 --> Access208
+    Access212{{"Access[212∈0] ➊<br />ᐸ15.m.joinDetailsFor146ᐳ"}}:::plan
+    PgSelect15 --> Access212
+    Access216{{"Access[216∈0] ➊<br />ᐸ20.m.subqueryDetailsFor128ᐳ"}}:::plan
+    PgSelect20 --> Access216
+    Access220{{"Access[220∈0] ➊<br />ᐸ25.m.joinDetailsFor153ᐳ"}}:::plan
+    PgSelect25 --> Access220
+    Access224{{"Access[224∈0] ➊<br />ᐸ30.m.subqueryDetailsFor134ᐳ"}}:::plan
+    PgSelect30 --> Access224
+    Access228{{"Access[228∈0] ➊<br />ᐸ35.m.joinDetailsFor160ᐳ"}}:::plan
+    PgSelect35 --> Access228
+    Access232{{"Access[232∈0] ➊<br />ᐸ40.m.subqueryDetailsFor140ᐳ"}}:::plan
+    PgSelect40 --> Access232
+    PageInfo70{{"PageInfo[70∈1] ➊<br />More deps:<br />- Connection[12]"}}:::plan
+    Access90{{"Access[90∈1] ➊<br />ᐸ12.hasNextPageᐳ<br />More deps:<br />- Connection[12]"}}:::plan
+    Access91{{"Access[91∈1] ➊<br />ᐸ12.hasPreviousPageᐳ<br />More deps:<br />- Connection[12]"}}:::plan
+    Edge72{{"Edge[72∈15]"}}:::plan
+    __Item71[/"__Item[71∈15]<br />ᐸ44ᐳ<br />More deps:<br />- ConnectionItems[44]"\]:::itemplan
+    PgCursor93{{"PgCursor[93∈15]<br />More deps:<br />- Access[86]"}}:::plan
+    __Item71 & PgCursor93 --> Edge72
+    __Item71 --> PgCursor93
+    __Item73[/"__Item[73∈16]<br />ᐸ47ᐳ"\]:::itemplan
+    ConnectionItems47 ==> __Item73
+    PgSelectSingle74{{"PgSelectSingle[74∈16]<br />ᐸlocation_tagsᐳ"}}:::plan
+    __Item73 --> PgSelectSingle74
+    __Item75[/"__Item[75∈17]<br />ᐸ50ᐳ"\]:::itemplan
+    ConnectionItems50 ==> __Item75
+    PgSelectSingle76{{"PgSelectSingle[76∈17]<br />ᐸlocationsᐳ"}}:::plan
+    __Item75 --> PgSelectSingle76
+    __Item77[/"__Item[77∈18]<br />ᐸ53ᐳ"\]:::itemplan
+    ConnectionItems53 ==> __Item77
+    PgSelectSingle78{{"PgSelectSingle[78∈18]<br />ᐸphoto_tagsᐳ"}}:::plan
+    __Item77 --> PgSelectSingle78
+    __Item79[/"__Item[79∈19]<br />ᐸ56ᐳ"\]:::itemplan
+    ConnectionItems56 ==> __Item79
+    PgSelectSingle80{{"PgSelectSingle[80∈19]<br />ᐸphotosᐳ"}}:::plan
+    __Item79 --> PgSelectSingle80
+    __Item81[/"__Item[81∈20]<br />ᐸ59ᐳ"\]:::itemplan
+    ConnectionItems59 ==> __Item81
+    PgSelectSingle82{{"PgSelectSingle[82∈20]<br />ᐸprofile_tagsᐳ"}}:::plan
+    __Item81 --> PgSelectSingle82
+    __Item83[/"__Item[83∈21]<br />ᐸ62ᐳ"\]:::itemplan
+    ConnectionItems62 ==> __Item83
+    PgSelectSingle84{{"PgSelectSingle[84∈21]<br />ᐸprofilesᐳ"}}:::plan
+    __Item83 --> PgSelectSingle84
+    PgSelectSingle124{{"PgSelectSingle[124∈22]<br />ᐸmeasurementsᐳ"}}:::plan
+    __Item71 --> PgSelectSingle124
+    List98{{"List[98∈23]<br />ᐸ94,95,96,97ᐳ<br />More deps:<br />- Constantᐸ'location_tags'ᐳ[94]"}}:::plan
+    PgClassExpression95{{"PgClassExpression[95∈23]<br />ᐸ__location...tity_kind”ᐳ"}}:::plan
+    PgClassExpression96{{"PgClassExpression[96∈23]<br />ᐸ__location...entity_id”ᐳ"}}:::plan
+    PgClassExpression97{{"PgClassExpression[97∈23]<br />ᐸ__location_tags__.”tag”ᐳ"}}:::plan
+    PgClassExpression95 & PgClassExpression96 & PgClassExpression97 --> List98
+    List213{{"List[213∈23]<br />ᐸ212,74ᐳ"}}:::plan
+    Access212 & PgSelectSingle74 --> List213
+    PgSelectSingle74 --> PgClassExpression95
+    PgSelectSingle74 --> PgClassExpression96
+    PgSelectSingle74 --> PgClassExpression97
+    Lambda99{{"Lambda[99∈23]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List98 --> Lambda99
+    First150{{"First[150∈23]"}}:::plan
+    PgSelectRows151[["PgSelectRows[151∈23]"]]:::plan
+    PgSelectRows151 --> First150
+    Lambda214{{"Lambda[214∈23]<br />ᐸpgInlineViaJoinTransformᐳ"}}:::plan
+    Lambda214 --> PgSelectRows151
+    PgSelectSingle152{{"PgSelectSingle[152∈23]<br />ᐸlocationsᐳ"}}:::plan
+    First150 --> PgSelectSingle152
+    List213 --> Lambda214
+    List102{{"List[102∈24]<br />ᐸ100,101ᐳ<br />More deps:<br />- Constantᐸ'locations'ᐳ[100]"}}:::plan
+    PgClassExpression101{{"PgClassExpression[101∈24]<br />ᐸ__locations__.”id”ᐳ"}}:::plan
+    PgClassExpression101 --> List102
+    List217{{"List[217∈24]<br />ᐸ216,75ᐳ"}}:::plan
+    Access216 & __Item75 --> List217
+    PgSelectSingle76 --> PgClassExpression101
+    Lambda103{{"Lambda[103∈24]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List102 --> Lambda103
+    Connection132[["Connection[132∈24]<br />ᐸ218ᐳ"]]:::plan
+    Lambda218{{"Lambda[218∈24]<br />ᐸpgInlineViaSubqueryTransformᐳ"}}:::plan
+    Lambda218 --> Connection132
+    ConnectionItems168[["ConnectionItems[168∈24]"]]:::plan
+    Connection132 --> ConnectionItems168
+    List217 --> Lambda218
+    List108{{"List[108∈25]<br />ᐸ104,105,106,107ᐳ<br />More deps:<br />- Constantᐸ'photo_tags'ᐳ[104]"}}:::plan
+    PgClassExpression105{{"PgClassExpression[105∈25]<br />ᐸ__photo_ta...tity_kind”ᐳ"}}:::plan
+    PgClassExpression106{{"PgClassExpression[106∈25]<br />ᐸ__photo_ta...entity_id”ᐳ"}}:::plan
+    PgClassExpression107{{"PgClassExpression[107∈25]<br />ᐸ__photo_tags__.”tag”ᐳ"}}:::plan
+    PgClassExpression105 & PgClassExpression106 & PgClassExpression107 --> List108
+    List221{{"List[221∈25]<br />ᐸ220,78ᐳ"}}:::plan
+    Access220 & PgSelectSingle78 --> List221
+    PgSelectSingle78 --> PgClassExpression105
+    PgSelectSingle78 --> PgClassExpression106
+    PgSelectSingle78 --> PgClassExpression107
+    Lambda109{{"Lambda[109∈25]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List108 --> Lambda109
+    First157{{"First[157∈25]"}}:::plan
+    PgSelectRows158[["PgSelectRows[158∈25]"]]:::plan
+    PgSelectRows158 --> First157
+    Lambda222{{"Lambda[222∈25]<br />ᐸpgInlineViaJoinTransformᐳ"}}:::plan
+    Lambda222 --> PgSelectRows158
+    PgSelectSingle159{{"PgSelectSingle[159∈25]<br />ᐸphotosᐳ"}}:::plan
+    First157 --> PgSelectSingle159
+    List221 --> Lambda222
+    List112{{"List[112∈26]<br />ᐸ110,111ᐳ<br />More deps:<br />- Constantᐸ'photos'ᐳ[110]"}}:::plan
+    PgClassExpression111{{"PgClassExpression[111∈26]<br />ᐸ__photos__.”id”ᐳ"}}:::plan
+    PgClassExpression111 --> List112
+    List225{{"List[225∈26]<br />ᐸ224,79ᐳ"}}:::plan
+    Access224 & __Item79 --> List225
+    PgSelectSingle80 --> PgClassExpression111
+    Lambda113{{"Lambda[113∈26]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List112 --> Lambda113
+    Connection138[["Connection[138∈26]<br />ᐸ226ᐳ"]]:::plan
+    Lambda226{{"Lambda[226∈26]<br />ᐸpgInlineViaSubqueryTransformᐳ"}}:::plan
+    Lambda226 --> Connection138
+    ConnectionItems171[["ConnectionItems[171∈26]"]]:::plan
+    Connection138 --> ConnectionItems171
+    List225 --> Lambda226
+    List118{{"List[118∈27]<br />ᐸ114,115,116,117ᐳ<br />More deps:<br />- Constantᐸ'profile_tags'ᐳ[114]"}}:::plan
+    PgClassExpression115{{"PgClassExpression[115∈27]<br />ᐸ__profile_...tity_kind”ᐳ"}}:::plan
+    PgClassExpression116{{"PgClassExpression[116∈27]<br />ᐸ__profile_...entity_id”ᐳ"}}:::plan
+    PgClassExpression117{{"PgClassExpression[117∈27]<br />ᐸ__profile_tags__.”tag”ᐳ"}}:::plan
+    PgClassExpression115 & PgClassExpression116 & PgClassExpression117 --> List118
+    List229{{"List[229∈27]<br />ᐸ228,82ᐳ"}}:::plan
+    Access228 & PgSelectSingle82 --> List229
+    PgSelectSingle82 --> PgClassExpression115
+    PgSelectSingle82 --> PgClassExpression116
+    PgSelectSingle82 --> PgClassExpression117
+    Lambda119{{"Lambda[119∈27]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List118 --> Lambda119
+    First164{{"First[164∈27]"}}:::plan
+    PgSelectRows165[["PgSelectRows[165∈27]"]]:::plan
+    PgSelectRows165 --> First164
+    Lambda230{{"Lambda[230∈27]<br />ᐸpgInlineViaJoinTransformᐳ"}}:::plan
+    Lambda230 --> PgSelectRows165
+    PgSelectSingle166{{"PgSelectSingle[166∈27]<br />ᐸprofilesᐳ"}}:::plan
+    First164 --> PgSelectSingle166
+    List229 --> Lambda230
+    List122{{"List[122∈28]<br />ᐸ120,121ᐳ<br />More deps:<br />- Constantᐸ'profiles'ᐳ[120]"}}:::plan
+    PgClassExpression121{{"PgClassExpression[121∈28]<br />ᐸ__profiles__.”id”ᐳ"}}:::plan
+    PgClassExpression121 --> List122
+    List233{{"List[233∈28]<br />ᐸ232,83ᐳ"}}:::plan
+    Access232 & __Item83 --> List233
+    PgSelectSingle84 --> PgClassExpression121
+    Lambda123{{"Lambda[123∈28]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List122 --> Lambda123
+    Connection144[["Connection[144∈28]<br />ᐸ234ᐳ"]]:::plan
+    Lambda234{{"Lambda[234∈28]<br />ᐸpgInlineViaSubqueryTransformᐳ"}}:::plan
+    Lambda234 --> Connection144
+    ConnectionItems174[["ConnectionItems[174∈28]"]]:::plan
+    Connection144 --> ConnectionItems174
+    List233 --> Lambda234
+    List209{{"List[209∈29]<br />ᐸ208,124ᐳ"}}:::plan
+    Access208 & PgSelectSingle124 --> List209
+    PgClassExpression167{{"PgClassExpression[167∈29]<br />ᐸ__measurem...timestamp”ᐳ"}}:::plan
+    PgSelectSingle124 --> PgClassExpression167
+    PgClassExpression186{{"PgClassExpression[186∈29]<br />ᐸ__measurements__.”key”ᐳ"}}:::plan
+    PgClassExpression167 o--o PgClassExpression186
+    PgClassExpression187{{"PgClassExpression[187∈29]<br />ᐸ__measurem...__.”value”ᐳ"}}:::plan
+    PgClassExpression186 o--o PgClassExpression187
+    First193{{"First[193∈29]"}}:::plan
+    PgSelectRows194[["PgSelectRows[194∈29]"]]:::plan
+    PgSelectRows194 --> First193
+    Lambda210{{"Lambda[210∈29]<br />ᐸpgInlineViaJoinTransformᐳ"}}:::plan
+    Lambda210 --> PgSelectRows194
+    PgSelectSingle195{{"PgSelectSingle[195∈29]<br />ᐸusersᐳ"}}:::plan
+    First193 --> PgSelectSingle195
+    List209 --> Lambda210
+    List178{{"List[178∈30]<br />ᐸ100,177ᐳ<br />More deps:<br />- Constantᐸ'locations'ᐳ[100]"}}:::plan
+    PgClassExpression177{{"PgClassExpression[177∈30]<br />ᐸ__locations__.”id”ᐳ"}}:::plan
+    PgClassExpression177 --> List178
+    PgSelectSingle152 --> PgClassExpression177
+    Lambda179{{"Lambda[179∈30]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List178 --> Lambda179
+    List181{{"List[181∈31]<br />ᐸ110,180ᐳ<br />More deps:<br />- Constantᐸ'photos'ᐳ[110]"}}:::plan
+    PgClassExpression180{{"PgClassExpression[180∈31]<br />ᐸ__photos__.”id”ᐳ"}}:::plan
+    PgClassExpression180 --> List181
+    PgSelectSingle159 --> PgClassExpression180
+    Lambda182{{"Lambda[182∈31]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List181 --> Lambda182
+    List184{{"List[184∈32]<br />ᐸ120,183ᐳ<br />More deps:<br />- Constantᐸ'profiles'ᐳ[120]"}}:::plan
+    PgClassExpression183{{"PgClassExpression[183∈32]<br />ᐸ__profiles__.”id”ᐳ"}}:::plan
+    PgClassExpression183 --> List184
+    PgSelectSingle166 --> PgClassExpression183
+    Lambda185{{"Lambda[185∈32]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List184 --> Lambda185
+    PgClassExpression202{{"PgClassExpression[202∈36]<br />ᐸ__users__.”id”ᐳ"}}:::plan
+    PgSelectSingle195 --> PgClassExpression202
+    PgClassExpression203{{"PgClassExpression[203∈36]<br />ᐸ__users__.”name”ᐳ"}}:::plan
+    PgClassExpression202 o--o PgClassExpression203
+    __Item196[/"__Item[196∈37]<br />ᐸ168ᐳ"\]:::itemplan
+    ConnectionItems168 ==> __Item196
+    PgSelectSingle197{{"PgSelectSingle[197∈37]<br />ᐸlocation_tagsᐳ"}}:::plan
+    __Item196 --> PgSelectSingle197
+    __Item198[/"__Item[198∈38]<br />ᐸ171ᐳ"\]:::itemplan
+    ConnectionItems171 ==> __Item198
+    PgSelectSingle199{{"PgSelectSingle[199∈38]<br />ᐸphoto_tagsᐳ"}}:::plan
+    __Item198 --> PgSelectSingle199
+    __Item200[/"__Item[200∈39]<br />ᐸ174ᐳ"\]:::itemplan
+    ConnectionItems174 ==> __Item200
+    PgSelectSingle201{{"PgSelectSingle[201∈39]<br />ᐸprofile_tagsᐳ"}}:::plan
+    __Item200 --> PgSelectSingle201
+    PgClassExpression204{{"PgClassExpression[204∈40]<br />ᐸ__location_tags__.”tag”ᐳ"}}:::plan
+    PgSelectSingle197 --> PgClassExpression204
+    PgClassExpression205{{"PgClassExpression[205∈41]<br />ᐸ__photo_tags__.”tag”ᐳ"}}:::plan
+    PgSelectSingle199 --> PgClassExpression205
+    PgClassExpression206{{"PgClassExpression[206∈42]<br />ᐸ__profile_tags__.”tag”ᐳ"}}:::plan
+    PgSelectSingle201 --> PgClassExpression206
 
     %% define steps
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,PgSelect8,Access9,Access10,Object11,Connection12,ConnectionItems14,PgSelect17,First18,PgSelectRows19,PgSelectSingle20,First25,Access26,Last28,PgSelectInlineApply48,Access49 bucket0
+    class Bucket0,__Value2,PgSelect8,Access9,Access10,Object11,Connection12,PgSelect15,Connection17,PgSelect20,Connection22,PgSelect25,Connection27,PgSelect30,Connection32,PgSelect35,Connection37,PgSelect40,Connection42,ConnectionItems44,ConnectionItems47,ConnectionItems50,ConnectionItems53,ConnectionItems56,ConnectionItems59,ConnectionItems62,PgSelect65,First66,PgSelectRows67,PgSelectSingle68,First85,Access86,Last88,PgSelectInlineApply207,Access208,PgSelectInlineApply211,Access212,PgSelectInlineApply215,Access216,PgSelectInlineApply219,Access220,PgSelectInlineApply223,Access224,PgSelectInlineApply227,Access228,PgSelectInlineApply231,Access232 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo22,Access30,Access31 bucket1
+    class Bucket1,PageInfo70,Access90,Access91 bucket1
+    classDef bucket2 stroke:#7f007f
+    class Bucket2 bucket2
     classDef bucket3 stroke:#ffa500
-    class Bucket3,__Item23,Edge24,PgCursor33 bucket3
+    class Bucket3 bucket3
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PgSelectSingle34 bucket4
+    class Bucket4 bucket4
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression35,PgClassExpression36,PgClassExpression37,First43,PgSelectRows44,PgSelectSingle45,List50,Lambda51 bucket5
+    class Bucket5 bucket5
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgClassExpression46,PgClassExpression47 bucket6
+    class Bucket6 bucket6
+    classDef bucket7 stroke:#808000
+    class Bucket7 bucket7
+    classDef bucket15 stroke:#ff00ff
+    class Bucket15,__Item71,Edge72,PgCursor93 bucket15
+    classDef bucket16 stroke:#f5deb3
+    class Bucket16,__Item73,PgSelectSingle74 bucket16
+    classDef bucket17 stroke:#696969
+    class Bucket17,__Item75,PgSelectSingle76 bucket17
+    classDef bucket18 stroke:#00bfff
+    class Bucket18,__Item77,PgSelectSingle78 bucket18
+    classDef bucket19 stroke:#7f007f
+    class Bucket19,__Item79,PgSelectSingle80 bucket19
+    classDef bucket20 stroke:#ffa500
+    class Bucket20,__Item81,PgSelectSingle82 bucket20
+    classDef bucket21 stroke:#0000ff
+    class Bucket21,__Item83,PgSelectSingle84 bucket21
+    classDef bucket22 stroke:#7fff00
+    class Bucket22,PgSelectSingle124 bucket22
+    classDef bucket23 stroke:#ff1493
+    class Bucket23,PgClassExpression95,PgClassExpression96,PgClassExpression97,List98,Lambda99,First150,PgSelectRows151,PgSelectSingle152,List213,Lambda214 bucket23
+    classDef bucket24 stroke:#808000
+    class Bucket24,PgClassExpression101,List102,Lambda103,Connection132,ConnectionItems168,List217,Lambda218 bucket24
+    classDef bucket25 stroke:#dda0dd
+    class Bucket25,PgClassExpression105,PgClassExpression106,PgClassExpression107,List108,Lambda109,First157,PgSelectRows158,PgSelectSingle159,List221,Lambda222 bucket25
+    classDef bucket26 stroke:#ff0000
+    class Bucket26,PgClassExpression111,List112,Lambda113,Connection138,ConnectionItems171,List225,Lambda226 bucket26
+    classDef bucket27 stroke:#ffff00
+    class Bucket27,PgClassExpression115,PgClassExpression116,PgClassExpression117,List118,Lambda119,First164,PgSelectRows165,PgSelectSingle166,List229,Lambda230 bucket27
+    classDef bucket28 stroke:#00ffff
+    class Bucket28,PgClassExpression121,List122,Lambda123,Connection144,ConnectionItems174,List233,Lambda234 bucket28
+    classDef bucket29 stroke:#4169e1
+    class Bucket29,PgClassExpression167,PgClassExpression186,PgClassExpression187,First193,PgSelectRows194,PgSelectSingle195,List209,Lambda210 bucket29
+    classDef bucket30 stroke:#3cb371
+    class Bucket30,PgClassExpression177,List178,Lambda179 bucket30
+    classDef bucket31 stroke:#a52a2a
+    class Bucket31,PgClassExpression180,List181,Lambda182 bucket31
+    classDef bucket32 stroke:#ff00ff
+    class Bucket32,PgClassExpression183,List184,Lambda185 bucket32
+    classDef bucket36 stroke:#7f007f
+    class Bucket36,PgClassExpression202,PgClassExpression203 bucket36
+    classDef bucket37 stroke:#ffa500
+    class Bucket37,__Item196,PgSelectSingle197 bucket37
+    classDef bucket38 stroke:#0000ff
+    class Bucket38,__Item198,PgSelectSingle199 bucket38
+    classDef bucket39 stroke:#7fff00
+    class Bucket39,__Item200,PgSelectSingle201 bucket39
+    classDef bucket40 stroke:#ff1493
+    class Bucket40,PgClassExpression204 bucket40
+    classDef bucket41 stroke:#808000
+    class Bucket41,PgClassExpression205 bucket41
+    classDef bucket42 stroke:#dda0dd
+    class Bucket42,PgClassExpression206 bucket42
 

--- a/postgraphile/postgraphile/__tests__/queries/v4/partitions.sql
+++ b/postgraphile/postgraphile/__tests__/queries/v4/partitions.sql
@@ -13,5 +13,89 @@ on (
 order by __measurements__."timestamp" asc, __measurements__."key" asc;
 
 select
+  __location_tags__."entity_kind"::text as "0",
+  __location_tags__."entity_id" as "1",
+  __location_tags__."tag" as "2",
+  __locations__."id" as "3"
+from "partitions"."location_tags" as __location_tags__
+left outer join "partitions"."locations" as __locations__
+on (
+/* WHERE becoming ON */ (
+  __locations__."id" = __location_tags__."entity_id"
+))
+order by __location_tags__."entity_kind" asc, __location_tags__."entity_id" asc, __location_tags__."tag" asc;
+
+select
+  __locations__."id" as "0",
+  array(
+    select array[
+      __location_tags__."tag"
+    ]::text[]
+    from "partitions"."location_tags" as __location_tags__
+    where (
+      __location_tags__."entity_id" = __locations__."id"
+    )
+    order by __location_tags__."entity_kind" asc, __location_tags__."entity_id" asc, __location_tags__."tag" asc
+  )::text as "1"
+from "partitions"."locations" as __locations__
+order by __locations__."id" asc;
+
+select
+  __photo_tags__."entity_kind"::text as "0",
+  __photo_tags__."entity_id" as "1",
+  __photo_tags__."tag" as "2",
+  __photos__."id" as "3"
+from "partitions"."photo_tags" as __photo_tags__
+left outer join "partitions"."photos" as __photos__
+on (
+/* WHERE becoming ON */ (
+  __photos__."id" = __photo_tags__."entity_id"
+))
+order by __photo_tags__."entity_kind" asc, __photo_tags__."entity_id" asc, __photo_tags__."tag" asc;
+
+select
+  __photos__."id" as "0",
+  array(
+    select array[
+      __photo_tags__."tag"
+    ]::text[]
+    from "partitions"."photo_tags" as __photo_tags__
+    where (
+      __photo_tags__."entity_id" = __photos__."id"
+    )
+    order by __photo_tags__."entity_kind" asc, __photo_tags__."entity_id" asc, __photo_tags__."tag" asc
+  )::text as "1"
+from "partitions"."photos" as __photos__
+order by __photos__."id" asc;
+
+select
+  __profile_tags__."entity_kind"::text as "0",
+  __profile_tags__."entity_id" as "1",
+  __profile_tags__."tag" as "2",
+  __profiles__."id" as "3"
+from "partitions"."profile_tags" as __profile_tags__
+left outer join "partitions"."profiles" as __profiles__
+on (
+/* WHERE becoming ON */ (
+  __profiles__."id" = __profile_tags__."entity_id"
+))
+order by __profile_tags__."entity_kind" asc, __profile_tags__."entity_id" asc, __profile_tags__."tag" asc;
+
+select
+  __profiles__."id" as "0",
+  array(
+    select array[
+      __profile_tags__."tag"
+    ]::text[]
+    from "partitions"."profile_tags" as __profile_tags__
+    where (
+      __profile_tags__."entity_id" = __profiles__."id"
+    )
+    order by __profile_tags__."entity_kind" asc, __profile_tags__."entity_id" asc, __profile_tags__."tag" asc
+  )::text as "1"
+from "partitions"."profiles" as __profiles__
+order by __profiles__."id" asc;
+
+select
   (count(*))::text as "0"
 from "partitions"."measurements" as __measurements__;

--- a/postgraphile/postgraphile/__tests__/queries/v4/partitions.test.graphql
+++ b/postgraphile/postgraphile/__tests__/queries/v4/partitions.test.graphql
@@ -17,6 +17,75 @@ query {
       hasPreviousPage
     }
   }
+  allLocationTags {
+    nodes {
+      nodeId
+      entityId
+      entityKind
+      tag
+      locationByEntityId {
+        nodeId
+        id
+      }
+    }
+  }
+  allLocations {
+    nodes {
+      nodeId
+      id
+      locationTagsByEntityId {
+        nodes {
+          tag
+        }
+      }
+    }
+  }
+  allPhotoTags {
+    nodes {
+      nodeId
+      entityId
+      entityKind
+      tag
+      photoByEntityId {
+        nodeId
+        id
+      }
+    }
+  }
+  allPhotos {
+    nodes {
+      nodeId
+      id
+      photoTagsByEntityId {
+        nodes {
+          tag
+        }
+      }
+    }
+  }
+  allProfileTags {
+    nodes {
+      nodeId
+      entityId
+      entityKind
+      tag
+      profileByEntityId {
+        nodeId
+        id
+      }
+    }
+  }
+  allProfiles {
+    nodes {
+      nodeId
+      id
+      profileTagsByEntityId {
+        nodes {
+          tag
+        }
+      }
+    }
+  }
 }
 
 fragment Measurement on Measurement {

--- a/postgraphile/postgraphile/__tests__/schema/v4/partitions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/partitions.1.export.mjs
@@ -174,6 +174,177 @@ const measurementsCodec = recordCodec({
   },
   executor: executor
 });
+const measurementsY2022Identifier = sql.identifier("partitions", "measurements_y2022");
+const measurementsY2022Codec = recordCodec({
+  name: "measurementsY2022",
+  identifier: measurementsY2022Identifier,
+  attributes: {
+    __proto__: null,
+    timestamp: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    key: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    value: {
+      description: undefined,
+      codec: TYPES.float,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    user_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  },
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "partitions",
+      name: "measurements_y2022"
+    },
+    tags: {
+      __proto__: null
+    }
+  },
+  executor: executor
+});
+const measurementsY2023Identifier = sql.identifier("partitions", "measurements_y2023");
+const measurementsY2023Codec = recordCodec({
+  name: "measurementsY2023",
+  identifier: measurementsY2023Identifier,
+  attributes: {
+    __proto__: null,
+    timestamp: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    key: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    value: {
+      description: undefined,
+      codec: TYPES.float,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    user_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  },
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "partitions",
+      name: "measurements_y2023"
+    },
+    tags: {
+      __proto__: null
+    }
+  },
+  executor: executor
+});
+const measurementsY2024Identifier = sql.identifier("partitions", "measurements_y2024");
+const measurementsY2024Codec = recordCodec({
+  name: "measurementsY2024",
+  identifier: measurementsY2024Identifier,
+  attributes: {
+    __proto__: null,
+    timestamp: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    key: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    value: {
+      description: undefined,
+      codec: TYPES.float,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    user_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  },
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "partitions",
+      name: "measurements_y2024"
+    },
+    tags: {
+      __proto__: null
+    }
+  },
+  executor: executor
+});
 const usersUniques = [{
   isPrimary: true,
   attributes: ["id"],
@@ -235,6 +406,112 @@ const registryConfig_pgResources_measurements_measurements = {
     isInsertable: true,
     isUpdatable: true,
     isDeletable: true,
+    hasPartitions: true,
+    tags: {}
+  }
+};
+const registryConfig_pgResources_measurements_y2022_measurements_y2022 = {
+  executor: executor,
+  name: "measurements_y2022",
+  identifier: "main.partitions.measurements_y2022",
+  from: measurementsY2022Identifier,
+  codec: measurementsY2022Codec,
+  uniques: [{
+    isPrimary: true,
+    attributes: ["timestamp", "key"],
+    description: undefined,
+    extensions: {
+      tags: {
+        __proto__: null
+      }
+    }
+  }],
+  isVirtual: false,
+  description: undefined,
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "partitions",
+      name: "measurements_y2022"
+    },
+    isInsertable: true,
+    isUpdatable: true,
+    isDeletable: true,
+    partitionParent: {
+      schemaName: "partitions",
+      name: "measurements"
+    },
+    tags: {}
+  }
+};
+const registryConfig_pgResources_measurements_y2023_measurements_y2023 = {
+  executor: executor,
+  name: "measurements_y2023",
+  identifier: "main.partitions.measurements_y2023",
+  from: measurementsY2023Identifier,
+  codec: measurementsY2023Codec,
+  uniques: [{
+    isPrimary: true,
+    attributes: ["timestamp", "key"],
+    description: undefined,
+    extensions: {
+      tags: {
+        __proto__: null
+      }
+    }
+  }],
+  isVirtual: false,
+  description: undefined,
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "partitions",
+      name: "measurements_y2023"
+    },
+    isInsertable: true,
+    isUpdatable: true,
+    isDeletable: true,
+    partitionParent: {
+      schemaName: "partitions",
+      name: "measurements"
+    },
+    tags: {}
+  }
+};
+const registryConfig_pgResources_measurements_y2024_measurements_y2024 = {
+  executor: executor,
+  name: "measurements_y2024",
+  identifier: "main.partitions.measurements_y2024",
+  from: measurementsY2024Identifier,
+  codec: measurementsY2024Codec,
+  uniques: [{
+    isPrimary: true,
+    attributes: ["timestamp", "key"],
+    description: undefined,
+    extensions: {
+      tags: {
+        __proto__: null
+      }
+    }
+  }],
+  isVirtual: false,
+  description: undefined,
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "partitions",
+      name: "measurements_y2024"
+    },
+    isInsertable: true,
+    isUpdatable: true,
+    isDeletable: true,
+    partitionParent: {
+      schemaName: "partitions",
+      name: "measurements"
+    },
     tags: {}
   }
 };
@@ -253,6 +530,9 @@ const registry = makeRegistry({
     timestamptz: TYPES.timestamptz,
     float8: TYPES.float,
     measurements: measurementsCodec,
+    measurementsY2022: measurementsY2022Codec,
+    measurementsY2023: measurementsY2023Codec,
+    measurementsY2024: measurementsY2024Codec,
     LetterAToDEnum: enumCodec({
       name: "LetterAToDEnum",
       identifier: TYPES.text.sqlType,
@@ -551,7 +831,10 @@ const registry = makeRegistry({
   pgResources: {
     __proto__: null,
     users: registryConfig_pgResources_users_users,
-    measurements: registryConfig_pgResources_measurements_measurements
+    measurements: registryConfig_pgResources_measurements_measurements,
+    measurements_y2022: registryConfig_pgResources_measurements_y2022_measurements_y2022,
+    measurements_y2023: registryConfig_pgResources_measurements_y2023_measurements_y2023,
+    measurements_y2024: registryConfig_pgResources_measurements_y2024_measurements_y2024
   },
   pgRelations: {
     __proto__: null,
@@ -573,11 +856,110 @@ const registry = makeRegistry({
         }
       }
     },
+    measurementsY2022: {
+      __proto__: null,
+      usersByMyUserId: {
+        localCodec: measurementsY2022Codec,
+        remoteResourceOptions: registryConfig_pgResources_users_users,
+        localCodecPolymorphicTypes: undefined,
+        localAttributes: ["user_id"],
+        remoteAttributes: ["id"],
+        isUnique: true,
+        isReferencee: false,
+        description: undefined,
+        extensions: {
+          tags: {
+            behavior: []
+          }
+        }
+      }
+    },
+    measurementsY2023: {
+      __proto__: null,
+      usersByMyUserId: {
+        localCodec: measurementsY2023Codec,
+        remoteResourceOptions: registryConfig_pgResources_users_users,
+        localCodecPolymorphicTypes: undefined,
+        localAttributes: ["user_id"],
+        remoteAttributes: ["id"],
+        isUnique: true,
+        isReferencee: false,
+        description: undefined,
+        extensions: {
+          tags: {
+            behavior: []
+          }
+        }
+      }
+    },
+    measurementsY2024: {
+      __proto__: null,
+      usersByMyUserId: {
+        localCodec: measurementsY2024Codec,
+        remoteResourceOptions: registryConfig_pgResources_users_users,
+        localCodecPolymorphicTypes: undefined,
+        localAttributes: ["user_id"],
+        remoteAttributes: ["id"],
+        isUnique: true,
+        isReferencee: false,
+        description: undefined,
+        extensions: {
+          tags: {
+            behavior: []
+          }
+        }
+      }
+    },
     users: {
       __proto__: null,
       measurementsByTheirUserId: {
         localCodec: usersCodec,
         remoteResourceOptions: registryConfig_pgResources_measurements_measurements,
+        localCodecPolymorphicTypes: undefined,
+        localAttributes: ["id"],
+        remoteAttributes: ["user_id"],
+        isUnique: false,
+        isReferencee: true,
+        description: undefined,
+        extensions: {
+          tags: {
+            behavior: []
+          }
+        }
+      },
+      measurementsY2022SByTheirUserId: {
+        localCodec: usersCodec,
+        remoteResourceOptions: registryConfig_pgResources_measurements_y2022_measurements_y2022,
+        localCodecPolymorphicTypes: undefined,
+        localAttributes: ["id"],
+        remoteAttributes: ["user_id"],
+        isUnique: false,
+        isReferencee: true,
+        description: undefined,
+        extensions: {
+          tags: {
+            behavior: []
+          }
+        }
+      },
+      measurementsY2023SByTheirUserId: {
+        localCodec: usersCodec,
+        remoteResourceOptions: registryConfig_pgResources_measurements_y2023_measurements_y2023,
+        localCodecPolymorphicTypes: undefined,
+        localAttributes: ["id"],
+        remoteAttributes: ["user_id"],
+        isUnique: false,
+        isReferencee: true,
+        description: undefined,
+        extensions: {
+          tags: {
+            behavior: []
+          }
+        }
+      },
+      measurementsY2024SByTheirUserId: {
+        localCodec: usersCodec,
+        remoteResourceOptions: registryConfig_pgResources_measurements_y2024_measurements_y2024,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
         remoteAttributes: ["user_id"],

--- a/postgraphile/postgraphile/__tests__/schema/v4/partitions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/partitions.1.export.mjs
@@ -78,6 +78,127 @@ const executor = new PgExecutor({
     });
   }
 });
+const entityKindsIdentifier = sql.identifier("partitions", "entity_kinds");
+const entityKindsCodec = recordCodec({
+  name: "entityKinds",
+  identifier: entityKindsIdentifier,
+  attributes: {
+    __proto__: null,
+    kind: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  },
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "partitions",
+      name: "entity_kinds"
+    },
+    tags: {
+      __proto__: null,
+      enum: true
+    }
+  },
+  executor: executor
+});
+const locationsIdentifier = sql.identifier("partitions", "locations");
+const locationsCodec = recordCodec({
+  name: "locations",
+  identifier: locationsIdentifier,
+  attributes: {
+    __proto__: null,
+    id: {
+      description: undefined,
+      codec: TYPES.uuid,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  },
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "partitions",
+      name: "locations"
+    },
+    tags: {
+      __proto__: null
+    }
+  },
+  executor: executor
+});
+const photosIdentifier = sql.identifier("partitions", "photos");
+const photosCodec = recordCodec({
+  name: "photos",
+  identifier: photosIdentifier,
+  attributes: {
+    __proto__: null,
+    id: {
+      description: undefined,
+      codec: TYPES.uuid,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  },
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "partitions",
+      name: "photos"
+    },
+    tags: {
+      __proto__: null
+    }
+  },
+  executor: executor
+});
+const profilesIdentifier = sql.identifier("partitions", "profiles");
+const profilesCodec = recordCodec({
+  name: "profiles",
+  identifier: profilesIdentifier,
+  attributes: {
+    __proto__: null,
+    id: {
+      description: undefined,
+      codec: TYPES.uuid,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  },
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "partitions",
+      name: "profiles"
+    },
+    tags: {
+      __proto__: null
+    }
+  },
+  executor: executor
+});
 const usersIdentifier = sql.identifier("partitions", "users");
 const usersCodec = recordCodec({
   name: "users",
@@ -110,6 +231,81 @@ const usersCodec = recordCodec({
       serviceName: "main",
       schemaName: "partitions",
       name: "users"
+    },
+    tags: {
+      __proto__: null
+    }
+  },
+  executor: executor
+});
+const locationTagsIdentifier = sql.identifier("partitions", "location_tags");
+const spec_locationTags_attributes_entity_kind_codec_EntityKindsEnum = enumCodec({
+  name: "EntityKindsEnum",
+  identifier: TYPES.text.sqlType,
+  values: [{
+    value: "photos",
+    description: undefined
+  }, {
+    value: "locations",
+    description: undefined
+  }, {
+    value: "profiles",
+    description: undefined
+  }],
+  extensions: {
+    isEnumTableEnum: true,
+    enumTableEnumDetails: {
+      serviceName: "main",
+      schemaName: "partitions",
+      tableName: "entity_kinds",
+      constraintType: "p",
+      constraintName: "entity_kinds_pkey"
+    },
+    tags: {
+      name: "EntityKinds"
+    }
+  }
+});
+const locationTagsCodec = recordCodec({
+  name: "locationTags",
+  identifier: locationTagsIdentifier,
+  attributes: {
+    __proto__: null,
+    entity_kind: {
+      description: undefined,
+      codec: spec_locationTags_attributes_entity_kind_codec_EntityKindsEnum,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    entity_id: {
+      description: undefined,
+      codec: TYPES.uuid,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    tag: {
+      description: undefined,
+      codec: TYPES.citext,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  },
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "partitions",
+      name: "location_tags"
     },
     tags: {
       __proto__: null
@@ -345,6 +541,279 @@ const measurementsY2024Codec = recordCodec({
   },
   executor: executor
 });
+const photoTagsIdentifier = sql.identifier("partitions", "photo_tags");
+const photoTagsCodec = recordCodec({
+  name: "photoTags",
+  identifier: photoTagsIdentifier,
+  attributes: {
+    __proto__: null,
+    entity_kind: {
+      description: undefined,
+      codec: spec_locationTags_attributes_entity_kind_codec_EntityKindsEnum,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    entity_id: {
+      description: undefined,
+      codec: TYPES.uuid,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    tag: {
+      description: undefined,
+      codec: TYPES.citext,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  },
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "partitions",
+      name: "photo_tags"
+    },
+    tags: {
+      __proto__: null
+    }
+  },
+  executor: executor
+});
+const profileTagsIdentifier = sql.identifier("partitions", "profile_tags");
+const profileTagsCodec = recordCodec({
+  name: "profileTags",
+  identifier: profileTagsIdentifier,
+  attributes: {
+    __proto__: null,
+    entity_kind: {
+      description: undefined,
+      codec: spec_locationTags_attributes_entity_kind_codec_EntityKindsEnum,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    entity_id: {
+      description: undefined,
+      codec: TYPES.uuid,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    tag: {
+      description: undefined,
+      codec: TYPES.citext,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  },
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "partitions",
+      name: "profile_tags"
+    },
+    tags: {
+      __proto__: null
+    }
+  },
+  executor: executor
+});
+const tagsIdentifier = sql.identifier("partitions", "tags");
+const tagsCodec = recordCodec({
+  name: "tags",
+  identifier: tagsIdentifier,
+  attributes: {
+    __proto__: null,
+    entity_kind: {
+      description: undefined,
+      codec: spec_locationTags_attributes_entity_kind_codec_EntityKindsEnum,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    entity_id: {
+      description: undefined,
+      codec: TYPES.uuid,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    tag: {
+      description: undefined,
+      codec: TYPES.citext,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  },
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "partitions",
+      name: "tags"
+    },
+    tags: {
+      __proto__: null
+    }
+  },
+  executor: executor
+});
+const registryConfig_pgResources_entity_kinds_entity_kinds = {
+  executor: executor,
+  name: "entity_kinds",
+  identifier: "main.partitions.entity_kinds",
+  from: entityKindsIdentifier,
+  codec: entityKindsCodec,
+  uniques: [{
+    isPrimary: true,
+    attributes: ["kind"],
+    description: undefined,
+    extensions: {
+      tags: {
+        __proto__: null
+      }
+    }
+  }],
+  isVirtual: false,
+  description: undefined,
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "partitions",
+      name: "entity_kinds"
+    },
+    isInsertable: true,
+    isUpdatable: true,
+    isDeletable: true,
+    tags: {
+      enum: true
+    }
+  }
+};
+const locationsUniques = [{
+  isPrimary: true,
+  attributes: ["id"],
+  description: undefined,
+  extensions: {
+    tags: {
+      __proto__: null
+    }
+  }
+}];
+const registryConfig_pgResources_locations_locations = {
+  executor: executor,
+  name: "locations",
+  identifier: "main.partitions.locations",
+  from: locationsIdentifier,
+  codec: locationsCodec,
+  uniques: locationsUniques,
+  isVirtual: false,
+  description: undefined,
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "partitions",
+      name: "locations"
+    },
+    isInsertable: true,
+    isUpdatable: true,
+    isDeletable: true,
+    tags: {}
+  }
+};
+const photosUniques = [{
+  isPrimary: true,
+  attributes: ["id"],
+  description: undefined,
+  extensions: {
+    tags: {
+      __proto__: null
+    }
+  }
+}];
+const registryConfig_pgResources_photos_photos = {
+  executor: executor,
+  name: "photos",
+  identifier: "main.partitions.photos",
+  from: photosIdentifier,
+  codec: photosCodec,
+  uniques: photosUniques,
+  isVirtual: false,
+  description: undefined,
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "partitions",
+      name: "photos"
+    },
+    isInsertable: true,
+    isUpdatable: true,
+    isDeletable: true,
+    tags: {}
+  }
+};
+const profilesUniques = [{
+  isPrimary: true,
+  attributes: ["id"],
+  description: undefined,
+  extensions: {
+    tags: {
+      __proto__: null
+    }
+  }
+}];
+const registryConfig_pgResources_profiles_profiles = {
+  executor: executor,
+  name: "profiles",
+  identifier: "main.partitions.profiles",
+  from: profilesIdentifier,
+  codec: profilesCodec,
+  uniques: profilesUniques,
+  isVirtual: false,
+  description: undefined,
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "partitions",
+      name: "profiles"
+    },
+    isInsertable: true,
+    isUpdatable: true,
+    isDeletable: true,
+    tags: {}
+  }
+};
 const usersUniques = [{
   isPrimary: true,
   attributes: ["id"],
@@ -402,6 +871,39 @@ const registryConfig_pgResources_measurements_measurements = {
       serviceName: "main",
       schemaName: "partitions",
       name: "measurements"
+    },
+    isInsertable: true,
+    isUpdatable: true,
+    isDeletable: true,
+    hasPartitions: true,
+    tags: {}
+  }
+};
+const tagsUniques = [{
+  isPrimary: true,
+  attributes: ["entity_kind", "entity_id", "tag"],
+  description: undefined,
+  extensions: {
+    tags: {
+      __proto__: null
+    }
+  }
+}];
+const registryConfig_pgResources_tags_tags = {
+  executor: executor,
+  name: "tags",
+  identifier: "main.partitions.tags",
+  from: tagsIdentifier,
+  codec: tagsCodec,
+  uniques: tagsUniques,
+  isVirtual: false,
+  description: undefined,
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "partitions",
+      name: "tags"
     },
     isInsertable: true,
     isUpdatable: true,
@@ -515,6 +1017,111 @@ const registryConfig_pgResources_measurements_y2024_measurements_y2024 = {
     tags: {}
   }
 };
+const registryConfig_pgResources_location_tags_location_tags = {
+  executor: executor,
+  name: "location_tags",
+  identifier: "main.partitions.location_tags",
+  from: locationTagsIdentifier,
+  codec: locationTagsCodec,
+  uniques: [{
+    isPrimary: true,
+    attributes: ["entity_kind", "entity_id", "tag"],
+    description: undefined,
+    extensions: {
+      tags: {
+        __proto__: null
+      }
+    }
+  }],
+  isVirtual: false,
+  description: undefined,
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "partitions",
+      name: "location_tags"
+    },
+    isInsertable: true,
+    isUpdatable: true,
+    isDeletable: true,
+    partitionParent: {
+      schemaName: "partitions",
+      name: "tags"
+    },
+    tags: {}
+  }
+};
+const registryConfig_pgResources_photo_tags_photo_tags = {
+  executor: executor,
+  name: "photo_tags",
+  identifier: "main.partitions.photo_tags",
+  from: photoTagsIdentifier,
+  codec: photoTagsCodec,
+  uniques: [{
+    isPrimary: true,
+    attributes: ["entity_kind", "entity_id", "tag"],
+    description: undefined,
+    extensions: {
+      tags: {
+        __proto__: null
+      }
+    }
+  }],
+  isVirtual: false,
+  description: undefined,
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "partitions",
+      name: "photo_tags"
+    },
+    isInsertable: true,
+    isUpdatable: true,
+    isDeletable: true,
+    partitionParent: {
+      schemaName: "partitions",
+      name: "tags"
+    },
+    tags: {}
+  }
+};
+const registryConfig_pgResources_profile_tags_profile_tags = {
+  executor: executor,
+  name: "profile_tags",
+  identifier: "main.partitions.profile_tags",
+  from: profileTagsIdentifier,
+  codec: profileTagsCodec,
+  uniques: [{
+    isPrimary: true,
+    attributes: ["entity_kind", "entity_id", "tag"],
+    description: undefined,
+    extensions: {
+      tags: {
+        __proto__: null
+      }
+    }
+  }],
+  isVirtual: false,
+  description: undefined,
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "partitions",
+      name: "profile_tags"
+    },
+    isInsertable: true,
+    isUpdatable: true,
+    isDeletable: true,
+    partitionParent: {
+      schemaName: "partitions",
+      name: "tags"
+    },
+    tags: {}
+  }
+};
 const registry = makeRegistry({
   pgExecutors: {
     __proto__: null,
@@ -522,17 +1129,28 @@ const registry = makeRegistry({
   },
   pgCodecs: {
     __proto__: null,
+    entityKinds: entityKindsCodec,
+    text: TYPES.text,
+    locations: locationsCodec,
+    uuid: TYPES.uuid,
+    photos: photosCodec,
+    profiles: profilesCodec,
     users: usersCodec,
     int4: TYPES.int,
-    text: TYPES.text,
     varchar: TYPES.varchar,
     bpchar: TYPES.bpchar,
     timestamptz: TYPES.timestamptz,
+    citext: TYPES.citext,
     float8: TYPES.float,
+    locationTags: locationTagsCodec,
+    EntityKindsEnum: spec_locationTags_attributes_entity_kind_codec_EntityKindsEnum,
     measurements: measurementsCodec,
     measurementsY2022: measurementsY2022Codec,
     measurementsY2023: measurementsY2023Codec,
     measurementsY2024: measurementsY2024Codec,
+    photoTags: photoTagsCodec,
+    profileTags: profileTagsCodec,
+    tags: tagsCodec,
     LetterAToDEnum: enumCodec({
       name: "LetterAToDEnum",
       identifier: TYPES.text.sqlType,
@@ -830,14 +1448,136 @@ const registry = makeRegistry({
   },
   pgResources: {
     __proto__: null,
+    entity_kinds: registryConfig_pgResources_entity_kinds_entity_kinds,
+    locations: registryConfig_pgResources_locations_locations,
+    photos: registryConfig_pgResources_photos_photos,
+    profiles: registryConfig_pgResources_profiles_profiles,
     users: registryConfig_pgResources_users_users,
     measurements: registryConfig_pgResources_measurements_measurements,
+    tags: registryConfig_pgResources_tags_tags,
     measurements_y2022: registryConfig_pgResources_measurements_y2022_measurements_y2022,
     measurements_y2023: registryConfig_pgResources_measurements_y2023_measurements_y2023,
-    measurements_y2024: registryConfig_pgResources_measurements_y2024_measurements_y2024
+    measurements_y2024: registryConfig_pgResources_measurements_y2024_measurements_y2024,
+    location_tags: registryConfig_pgResources_location_tags_location_tags,
+    photo_tags: registryConfig_pgResources_photo_tags_photo_tags,
+    profile_tags: registryConfig_pgResources_profile_tags_profile_tags
   },
   pgRelations: {
     __proto__: null,
+    entityKinds: {
+      __proto__: null,
+      tagsByTheirEntityKind: {
+        localCodec: entityKindsCodec,
+        remoteResourceOptions: registryConfig_pgResources_tags_tags,
+        localCodecPolymorphicTypes: undefined,
+        localAttributes: ["kind"],
+        remoteAttributes: ["entity_kind"],
+        isUnique: false,
+        isReferencee: true,
+        description: undefined,
+        extensions: {
+          tags: {
+            behavior: []
+          }
+        }
+      },
+      photoTagsByTheirEntityKind: {
+        localCodec: entityKindsCodec,
+        remoteResourceOptions: registryConfig_pgResources_photo_tags_photo_tags,
+        localCodecPolymorphicTypes: undefined,
+        localAttributes: ["kind"],
+        remoteAttributes: ["entity_kind"],
+        isUnique: false,
+        isReferencee: true,
+        description: undefined,
+        extensions: {
+          tags: {
+            behavior: []
+          }
+        }
+      },
+      locationTagsByTheirEntityKind: {
+        localCodec: entityKindsCodec,
+        remoteResourceOptions: registryConfig_pgResources_location_tags_location_tags,
+        localCodecPolymorphicTypes: undefined,
+        localAttributes: ["kind"],
+        remoteAttributes: ["entity_kind"],
+        isUnique: false,
+        isReferencee: true,
+        description: undefined,
+        extensions: {
+          tags: {
+            behavior: []
+          }
+        }
+      },
+      profileTagsByTheirEntityKind: {
+        localCodec: entityKindsCodec,
+        remoteResourceOptions: registryConfig_pgResources_profile_tags_profile_tags,
+        localCodecPolymorphicTypes: undefined,
+        localAttributes: ["kind"],
+        remoteAttributes: ["entity_kind"],
+        isUnique: false,
+        isReferencee: true,
+        description: undefined,
+        extensions: {
+          tags: {
+            behavior: []
+          }
+        }
+      }
+    },
+    locationTags: {
+      __proto__: null,
+      locationsByMyEntityId: {
+        localCodec: locationTagsCodec,
+        remoteResourceOptions: registryConfig_pgResources_locations_locations,
+        localCodecPolymorphicTypes: undefined,
+        localAttributes: ["entity_id"],
+        remoteAttributes: ["id"],
+        isUnique: true,
+        isReferencee: false,
+        description: undefined,
+        extensions: {
+          tags: {
+            behavior: []
+          }
+        }
+      },
+      entityKindsByMyEntityKind: {
+        localCodec: locationTagsCodec,
+        remoteResourceOptions: registryConfig_pgResources_entity_kinds_entity_kinds,
+        localCodecPolymorphicTypes: undefined,
+        localAttributes: ["entity_kind"],
+        remoteAttributes: ["kind"],
+        isUnique: true,
+        isReferencee: false,
+        description: undefined,
+        extensions: {
+          tags: {
+            behavior: []
+          }
+        }
+      }
+    },
+    locations: {
+      __proto__: null,
+      locationTagsByTheirEntityId: {
+        localCodec: locationsCodec,
+        remoteResourceOptions: registryConfig_pgResources_location_tags_location_tags,
+        localCodecPolymorphicTypes: undefined,
+        localAttributes: ["id"],
+        remoteAttributes: ["entity_id"],
+        isUnique: false,
+        isReferencee: true,
+        description: undefined,
+        extensions: {
+          tags: {
+            behavior: []
+          }
+        }
+      }
+    },
     measurements: {
       __proto__: null,
       usersByMyUserId: {
@@ -900,6 +1640,126 @@ const registry = makeRegistry({
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["user_id"],
         remoteAttributes: ["id"],
+        isUnique: true,
+        isReferencee: false,
+        description: undefined,
+        extensions: {
+          tags: {
+            behavior: []
+          }
+        }
+      }
+    },
+    photoTags: {
+      __proto__: null,
+      photosByMyEntityId: {
+        localCodec: photoTagsCodec,
+        remoteResourceOptions: registryConfig_pgResources_photos_photos,
+        localCodecPolymorphicTypes: undefined,
+        localAttributes: ["entity_id"],
+        remoteAttributes: ["id"],
+        isUnique: true,
+        isReferencee: false,
+        description: undefined,
+        extensions: {
+          tags: {
+            behavior: []
+          }
+        }
+      },
+      entityKindsByMyEntityKind: {
+        localCodec: photoTagsCodec,
+        remoteResourceOptions: registryConfig_pgResources_entity_kinds_entity_kinds,
+        localCodecPolymorphicTypes: undefined,
+        localAttributes: ["entity_kind"],
+        remoteAttributes: ["kind"],
+        isUnique: true,
+        isReferencee: false,
+        description: undefined,
+        extensions: {
+          tags: {
+            behavior: []
+          }
+        }
+      }
+    },
+    photos: {
+      __proto__: null,
+      photoTagsByTheirEntityId: {
+        localCodec: photosCodec,
+        remoteResourceOptions: registryConfig_pgResources_photo_tags_photo_tags,
+        localCodecPolymorphicTypes: undefined,
+        localAttributes: ["id"],
+        remoteAttributes: ["entity_id"],
+        isUnique: false,
+        isReferencee: true,
+        description: undefined,
+        extensions: {
+          tags: {
+            behavior: []
+          }
+        }
+      }
+    },
+    profileTags: {
+      __proto__: null,
+      profilesByMyEntityId: {
+        localCodec: profileTagsCodec,
+        remoteResourceOptions: registryConfig_pgResources_profiles_profiles,
+        localCodecPolymorphicTypes: undefined,
+        localAttributes: ["entity_id"],
+        remoteAttributes: ["id"],
+        isUnique: true,
+        isReferencee: false,
+        description: undefined,
+        extensions: {
+          tags: {
+            behavior: []
+          }
+        }
+      },
+      entityKindsByMyEntityKind: {
+        localCodec: profileTagsCodec,
+        remoteResourceOptions: registryConfig_pgResources_entity_kinds_entity_kinds,
+        localCodecPolymorphicTypes: undefined,
+        localAttributes: ["entity_kind"],
+        remoteAttributes: ["kind"],
+        isUnique: true,
+        isReferencee: false,
+        description: undefined,
+        extensions: {
+          tags: {
+            behavior: []
+          }
+        }
+      }
+    },
+    profiles: {
+      __proto__: null,
+      profileTagsByTheirEntityId: {
+        localCodec: profilesCodec,
+        remoteResourceOptions: registryConfig_pgResources_profile_tags_profile_tags,
+        localCodecPolymorphicTypes: undefined,
+        localAttributes: ["id"],
+        remoteAttributes: ["entity_id"],
+        isUnique: false,
+        isReferencee: true,
+        description: undefined,
+        extensions: {
+          tags: {
+            behavior: []
+          }
+        }
+      }
+    },
+    tags: {
+      __proto__: null,
+      entityKindsByMyEntityKind: {
+        localCodec: tagsCodec,
+        remoteResourceOptions: registryConfig_pgResources_entity_kinds_entity_kinds,
+        localCodecPolymorphicTypes: undefined,
+        localAttributes: ["entity_kind"],
+        remoteAttributes: ["kind"],
         isUnique: true,
         isReferencee: false,
         description: undefined,
@@ -975,14 +1835,18 @@ const registry = makeRegistry({
     }
   }
 });
+const resource_locationsPgResource = registry.pgResources["locations"];
+const resource_photosPgResource = registry.pgResources["photos"];
+const resource_profilesPgResource = registry.pgResources["profiles"];
 const resource_usersPgResource = registry.pgResources["users"];
 const resource_measurementsPgResource = registry.pgResources["measurements"];
-const nodeIdHandler_User = {
-  typeName: "User",
+const resource_tagsPgResource = registry.pgResources["tags"];
+const nodeIdHandler_Location = {
+  typeName: "Location",
   codec: nodeIdCodecs_base64JSON_base64JSON,
   deprecationReason: undefined,
   plan($record) {
-    return list([constant("users", false), $record.get("id")]);
+    return list([constant("locations", false), $record.get("id")]);
   },
   getSpec($list) {
     return {
@@ -993,10 +1857,10 @@ const nodeIdHandler_User = {
     return value.slice(1);
   },
   get(spec) {
-    return resource_usersPgResource.get(spec);
+    return resource_locationsPgResource.get(spec);
   },
   match(obj) {
-    return obj[0] === "users";
+    return obj[0] === "locations";
   }
 };
 const specForHandlerCache = new Map();
@@ -1024,6 +1888,84 @@ function specForHandler(handler) {
   specForHandlerCache.set(handler, spec);
   return spec;
 }
+const nodeFetcher_Location = $nodeId => {
+  const $decoded = lambda($nodeId, specForHandler(nodeIdHandler_Location));
+  return nodeIdHandler_Location.get(nodeIdHandler_Location.getSpec($decoded));
+};
+const nodeIdHandler_Photo = {
+  typeName: "Photo",
+  codec: nodeIdCodecs_base64JSON_base64JSON,
+  deprecationReason: undefined,
+  plan($record) {
+    return list([constant("photos", false), $record.get("id")]);
+  },
+  getSpec($list) {
+    return {
+      id: inhibitOnNull(access($list, [1]))
+    };
+  },
+  getIdentifiers(value) {
+    return value.slice(1);
+  },
+  get(spec) {
+    return resource_photosPgResource.get(spec);
+  },
+  match(obj) {
+    return obj[0] === "photos";
+  }
+};
+const nodeFetcher_Photo = $nodeId => {
+  const $decoded = lambda($nodeId, specForHandler(nodeIdHandler_Photo));
+  return nodeIdHandler_Photo.get(nodeIdHandler_Photo.getSpec($decoded));
+};
+const nodeIdHandler_Profile = {
+  typeName: "Profile",
+  codec: nodeIdCodecs_base64JSON_base64JSON,
+  deprecationReason: undefined,
+  plan($record) {
+    return list([constant("profiles", false), $record.get("id")]);
+  },
+  getSpec($list) {
+    return {
+      id: inhibitOnNull(access($list, [1]))
+    };
+  },
+  getIdentifiers(value) {
+    return value.slice(1);
+  },
+  get(spec) {
+    return resource_profilesPgResource.get(spec);
+  },
+  match(obj) {
+    return obj[0] === "profiles";
+  }
+};
+const nodeFetcher_Profile = $nodeId => {
+  const $decoded = lambda($nodeId, specForHandler(nodeIdHandler_Profile));
+  return nodeIdHandler_Profile.get(nodeIdHandler_Profile.getSpec($decoded));
+};
+const nodeIdHandler_User = {
+  typeName: "User",
+  codec: nodeIdCodecs_base64JSON_base64JSON,
+  deprecationReason: undefined,
+  plan($record) {
+    return list([constant("users", false), $record.get("id")]);
+  },
+  getSpec($list) {
+    return {
+      id: inhibitOnNull(access($list, [1]))
+    };
+  },
+  getIdentifiers(value) {
+    return value.slice(1);
+  },
+  get(spec) {
+    return resource_usersPgResource.get(spec);
+  },
+  match(obj) {
+    return obj[0] === "users";
+  }
+};
 const nodeFetcher_User = $nodeId => {
   const $decoded = lambda($nodeId, specForHandler(nodeIdHandler_User));
   return nodeIdHandler_User.get(nodeIdHandler_User.getSpec($decoded));
@@ -1055,14 +1997,46 @@ const nodeFetcher_Measurement = $nodeId => {
   const $decoded = lambda($nodeId, specForHandler(nodeIdHandler_Measurement));
   return nodeIdHandler_Measurement.get(nodeIdHandler_Measurement.getSpec($decoded));
 };
+const nodeIdHandler_Tag = {
+  typeName: "Tag",
+  codec: nodeIdCodecs_base64JSON_base64JSON,
+  deprecationReason: undefined,
+  plan($record) {
+    return list([constant("tags", false), $record.get("entity_kind"), $record.get("entity_id"), $record.get("tag")]);
+  },
+  getSpec($list) {
+    return {
+      entity_kind: inhibitOnNull(access($list, [1])),
+      entity_id: inhibitOnNull(access($list, [2])),
+      tag: inhibitOnNull(access($list, [3]))
+    };
+  },
+  getIdentifiers(value) {
+    return value.slice(1);
+  },
+  get(spec) {
+    return resource_tagsPgResource.get(spec);
+  },
+  match(obj) {
+    return obj[0] === "tags";
+  }
+};
+const nodeFetcher_Tag = $nodeId => {
+  const $decoded = lambda($nodeId, specForHandler(nodeIdHandler_Tag));
+  return nodeIdHandler_Tag.get(nodeIdHandler_Tag.getSpec($decoded));
+};
 function qbWhereBuilder(qb) {
   return qb.whereBuilder();
 }
 const nodeIdHandlerByTypeName = {
   __proto__: null,
   Query: nodeIdHandler_Query,
+  Location: nodeIdHandler_Location,
+  Photo: nodeIdHandler_Photo,
+  Profile: nodeIdHandler_Profile,
   User: nodeIdHandler_User,
-  Measurement: nodeIdHandler_Measurement
+  Measurement: nodeIdHandler_Measurement,
+  Tag: nodeIdHandler_Tag
 };
 const decodeNodeId = makeDecodeNodeId(Object.values(nodeIdHandlerByTypeName));
 function findTypeNameMatch(specifier) {
@@ -1075,9 +2049,27 @@ function findTypeNameMatch(specifier) {
   }
   return null;
 }
-function DatetimeSerialize(value) {
+function UUIDSerialize(value) {
   return "" + value;
 }
+const coerce = string => {
+  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
+    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hyphens");
+  }
+  return string;
+};
+const specFromArgs_Location = args => {
+  const $nodeId = args.getRaw(["input", "nodeId"]);
+  return specFromNodeId(nodeIdHandler_Location, $nodeId);
+};
+const specFromArgs_Photo = args => {
+  const $nodeId = args.getRaw(["input", "nodeId"]);
+  return specFromNodeId(nodeIdHandler_Photo, $nodeId);
+};
+const specFromArgs_Profile = args => {
+  const $nodeId = args.getRaw(["input", "nodeId"]);
+  return specFromNodeId(nodeIdHandler_Profile, $nodeId);
+};
 const specFromArgs_User = args => {
   const $nodeId = args.getRaw(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandler_User, $nodeId);
@@ -1086,6 +2078,22 @@ const specFromArgs_Measurement = args => {
   const $nodeId = args.getRaw(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandler_Measurement, $nodeId);
 };
+const specFromArgs_Tag = args => {
+  const $nodeId = args.getRaw(["input", "nodeId"]);
+  return specFromNodeId(nodeIdHandler_Tag, $nodeId);
+};
+const specFromArgs_Location2 = args => {
+  const $nodeId = args.getRaw(["input", "nodeId"]);
+  return specFromNodeId(nodeIdHandler_Location, $nodeId);
+};
+const specFromArgs_Photo2 = args => {
+  const $nodeId = args.getRaw(["input", "nodeId"]);
+  return specFromNodeId(nodeIdHandler_Photo, $nodeId);
+};
+const specFromArgs_Profile2 = args => {
+  const $nodeId = args.getRaw(["input", "nodeId"]);
+  return specFromNodeId(nodeIdHandler_Profile, $nodeId);
+};
 const specFromArgs_User2 = args => {
   const $nodeId = args.getRaw(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandler_User, $nodeId);
@@ -1093,6 +2101,10 @@ const specFromArgs_User2 = args => {
 const specFromArgs_Measurement2 = args => {
   const $nodeId = args.getRaw(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandler_Measurement, $nodeId);
+};
+const specFromArgs_Tag2 = args => {
+  const $nodeId = args.getRaw(["input", "nodeId"]);
+  return specFromNodeId(nodeIdHandler_Tag, $nodeId);
 };
 const getPgSelectSingleFromMutationResult = (resource, pkAttributes, $mutation) => {
   const $result = $mutation.getStepForKey("result", true);
@@ -1133,11 +2145,41 @@ type Query implements Node {
     nodeId: ID!
   ): Node
 
+  """Get a single \`Location\`."""
+  locationById(id: UUID!): Location
+
+  """Get a single \`Photo\`."""
+  photoById(id: UUID!): Photo
+
+  """Get a single \`Profile\`."""
+  profileById(id: UUID!): Profile
+
   """Get a single \`User\`."""
   userById(id: Int!): User
 
   """Get a single \`Measurement\`."""
   measurementByTimestampAndKey(timestamp: Datetime!, key: String!): Measurement
+
+  """Get a single \`Tag\`."""
+  tagByEntityKindAndEntityIdAndTag(entityKind: EntityKinds!, entityId: UUID!, tag: String!): Tag
+
+  """Reads a single \`Location\` using its globally unique \`ID\`."""
+  location(
+    """The globally unique \`ID\` to be used in selecting a single \`Location\`."""
+    nodeId: ID!
+  ): Location
+
+  """Reads a single \`Photo\` using its globally unique \`ID\`."""
+  photo(
+    """The globally unique \`ID\` to be used in selecting a single \`Photo\`."""
+    nodeId: ID!
+  ): Photo
+
+  """Reads a single \`Profile\` using its globally unique \`ID\`."""
+  profile(
+    """The globally unique \`ID\` to be used in selecting a single \`Profile\`."""
+    nodeId: ID!
+  ): Profile
 
   """Reads a single \`User\` using its globally unique \`ID\`."""
   user(
@@ -1152,6 +2194,99 @@ type Query implements Node {
     """
     nodeId: ID!
   ): Measurement
+
+  """Reads a single \`Tag\` using its globally unique \`ID\`."""
+  tag(
+    """The globally unique \`ID\` to be used in selecting a single \`Tag\`."""
+    nodeId: ID!
+  ): Tag
+
+  """Reads and enables pagination through a set of \`Location\`."""
+  allLocations(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: LocationCondition
+
+    """The method to use when ordering \`Location\`."""
+    orderBy: [LocationsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LocationsConnection
+
+  """Reads and enables pagination through a set of \`Photo\`."""
+  allPhotos(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PhotoCondition
+
+    """The method to use when ordering \`Photo\`."""
+    orderBy: [PhotosOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PhotosConnection
+
+  """Reads and enables pagination through a set of \`Profile\`."""
+  allProfiles(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProfileCondition
+
+    """The method to use when ordering \`Profile\`."""
+    orderBy: [ProfilesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProfilesConnection
 
   """Reads and enables pagination through a set of \`User\`."""
   allUsers(
@@ -1210,6 +2345,35 @@ type Query implements Node {
     """The method to use when ordering \`Measurement\`."""
     orderBy: [MeasurementsOrderBy!] = [PRIMARY_KEY_ASC]
   ): MeasurementsConnection
+
+  """Reads and enables pagination through a set of \`Tag\`."""
+  allTags(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TagCondition
+
+    """The method to use when ordering \`Tag\`."""
+    orderBy: [TagsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): TagsConnection
 }
 
 """An object with a globally unique \`ID\`."""
@@ -1218,6 +2382,35 @@ interface Node {
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
+}
+
+type Location implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: UUID!
+}
+
+"""
+A universally unique identifier as defined by [RFC 4122](https://tools.ietf.org/html/rfc4122).
+"""
+scalar UUID
+
+type Photo implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: UUID!
+}
+
+type Profile implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: UUID!
 }
 
 type User implements Node {
@@ -1358,6 +2551,152 @@ enum MeasurementsOrderBy {
   USER_ID_DESC
 }
 
+type Tag implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  entityKind: EntityKinds!
+  entityId: UUID!
+  tag: String!
+}
+
+enum EntityKinds {
+  PHOTOS
+  LOCATIONS
+  PROFILES
+}
+
+"""A connection to a list of \`Location\` values."""
+type LocationsConnection {
+  """A list of \`Location\` objects."""
+  nodes: [Location]!
+
+  """
+  A list of edges which contains the \`Location\` and cursor to aid in pagination.
+  """
+  edges: [LocationsEdge]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Location\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Location\` edge in the connection."""
+type LocationsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Location\` at the end of the edge."""
+  node: Location
+}
+
+"""
+A condition to be used against \`Location\` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input LocationCondition {
+  """Checks for equality with the object’s \`id\` field."""
+  id: UUID
+}
+
+"""Methods to use when ordering \`Location\`."""
+enum LocationsOrderBy {
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  ID_ASC
+  ID_DESC
+}
+
+"""A connection to a list of \`Photo\` values."""
+type PhotosConnection {
+  """A list of \`Photo\` objects."""
+  nodes: [Photo]!
+
+  """
+  A list of edges which contains the \`Photo\` and cursor to aid in pagination.
+  """
+  edges: [PhotosEdge]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Photo\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Photo\` edge in the connection."""
+type PhotosEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Photo\` at the end of the edge."""
+  node: Photo
+}
+
+"""
+A condition to be used against \`Photo\` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input PhotoCondition {
+  """Checks for equality with the object’s \`id\` field."""
+  id: UUID
+}
+
+"""Methods to use when ordering \`Photo\`."""
+enum PhotosOrderBy {
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  ID_ASC
+  ID_DESC
+}
+
+"""A connection to a list of \`Profile\` values."""
+type ProfilesConnection {
+  """A list of \`Profile\` objects."""
+  nodes: [Profile]!
+
+  """
+  A list of edges which contains the \`Profile\` and cursor to aid in pagination.
+  """
+  edges: [ProfilesEdge]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Profile\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Profile\` edge in the connection."""
+type ProfilesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Profile\` at the end of the edge."""
+  node: Profile
+}
+
+"""
+A condition to be used against \`Profile\` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input ProfileCondition {
+  """Checks for equality with the object’s \`id\` field."""
+  id: UUID
+}
+
+"""Methods to use when ordering \`Profile\`."""
+enum ProfilesOrderBy {
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  ID_ASC
+  ID_DESC
+}
+
 """A connection to a list of \`User\` values."""
 type UsersConnection {
   """A list of \`User\` objects."""
@@ -1406,10 +2745,87 @@ enum UsersOrderBy {
   NAME_DESC
 }
 
+"""A connection to a list of \`Tag\` values."""
+type TagsConnection {
+  """A list of \`Tag\` objects."""
+  nodes: [Tag]!
+
+  """
+  A list of edges which contains the \`Tag\` and cursor to aid in pagination.
+  """
+  edges: [TagsEdge]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Tag\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Tag\` edge in the connection."""
+type TagsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Tag\` at the end of the edge."""
+  node: Tag
+}
+
+"""
+A condition to be used against \`Tag\` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input TagCondition {
+  """Checks for equality with the object’s \`entityKind\` field."""
+  entityKind: EntityKinds
+
+  """Checks for equality with the object’s \`entityId\` field."""
+  entityId: UUID
+
+  """Checks for equality with the object’s \`tag\` field."""
+  tag: String
+}
+
+"""Methods to use when ordering \`Tag\`."""
+enum TagsOrderBy {
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  ENTITY_KIND_ASC
+  ENTITY_KIND_DESC
+  ENTITY_ID_ASC
+  ENTITY_ID_DESC
+  TAG_ASC
+  TAG_DESC
+}
+
 """
 The root mutation type which contains root level fields which mutate data.
 """
 type Mutation {
+  """Creates a single \`Location\`."""
+  createLocation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateLocationInput!
+  ): CreateLocationPayload
+
+  """Creates a single \`Photo\`."""
+  createPhoto(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreatePhotoInput!
+  ): CreatePhotoPayload
+
+  """Creates a single \`Profile\`."""
+  createProfile(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateProfileInput!
+  ): CreateProfilePayload
+
   """Creates a single \`User\`."""
   createUser(
     """
@@ -1425,6 +2841,62 @@ type Mutation {
     """
     input: CreateMeasurementInput!
   ): CreateMeasurementPayload
+
+  """Creates a single \`Tag\`."""
+  createTag(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateTagInput!
+  ): CreateTagPayload
+
+  """Updates a single \`Location\` using its globally unique id and a patch."""
+  updateLocation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateLocationInput!
+  ): UpdateLocationPayload
+
+  """Updates a single \`Location\` using a unique key and a patch."""
+  updateLocationById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateLocationByIdInput!
+  ): UpdateLocationPayload
+
+  """Updates a single \`Photo\` using its globally unique id and a patch."""
+  updatePhoto(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdatePhotoInput!
+  ): UpdatePhotoPayload
+
+  """Updates a single \`Photo\` using a unique key and a patch."""
+  updatePhotoById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdatePhotoByIdInput!
+  ): UpdatePhotoPayload
+
+  """Updates a single \`Profile\` using its globally unique id and a patch."""
+  updateProfile(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateProfileInput!
+  ): UpdateProfilePayload
+
+  """Updates a single \`Profile\` using a unique key and a patch."""
+  updateProfileById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateProfileByIdInput!
+  ): UpdateProfilePayload
 
   """Updates a single \`User\` using its globally unique id and a patch."""
   updateUser(
@@ -1460,6 +2932,70 @@ type Mutation {
     input: UpdateMeasurementByTimestampAndKeyInput!
   ): UpdateMeasurementPayload
 
+  """Updates a single \`Tag\` using its globally unique id and a patch."""
+  updateTag(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateTagInput!
+  ): UpdateTagPayload
+
+  """Updates a single \`Tag\` using a unique key and a patch."""
+  updateTagByEntityKindAndEntityIdAndTag(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateTagByEntityKindAndEntityIdAndTagInput!
+  ): UpdateTagPayload
+
+  """Deletes a single \`Location\` using its globally unique id."""
+  deleteLocation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteLocationInput!
+  ): DeleteLocationPayload
+
+  """Deletes a single \`Location\` using a unique key."""
+  deleteLocationById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteLocationByIdInput!
+  ): DeleteLocationPayload
+
+  """Deletes a single \`Photo\` using its globally unique id."""
+  deletePhoto(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeletePhotoInput!
+  ): DeletePhotoPayload
+
+  """Deletes a single \`Photo\` using a unique key."""
+  deletePhotoById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeletePhotoByIdInput!
+  ): DeletePhotoPayload
+
+  """Deletes a single \`Profile\` using its globally unique id."""
+  deleteProfile(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteProfileInput!
+  ): DeleteProfilePayload
+
+  """Deletes a single \`Profile\` using a unique key."""
+  deleteProfileById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteProfileByIdInput!
+  ): DeleteProfilePayload
+
   """Deletes a single \`User\` using its globally unique id."""
   deleteUser(
     """
@@ -1491,6 +3027,142 @@ type Mutation {
     """
     input: DeleteMeasurementByTimestampAndKeyInput!
   ): DeleteMeasurementPayload
+
+  """Deletes a single \`Tag\` using its globally unique id."""
+  deleteTag(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteTagInput!
+  ): DeleteTagPayload
+
+  """Deletes a single \`Tag\` using a unique key."""
+  deleteTagByEntityKindAndEntityIdAndTag(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteTagByEntityKindAndEntityIdAndTagInput!
+  ): DeleteTagPayload
+}
+
+"""The output of our create \`Location\` mutation."""
+type CreateLocationPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Location\` that was created by this mutation."""
+  location: Location
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our \`Location\`. May be used by Relay 1."""
+  locationEdge(
+    """The method to use when ordering \`Location\`."""
+    orderBy: [LocationsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): LocationsEdge
+}
+
+"""All input for the create \`Location\` mutation."""
+input CreateLocationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The \`Location\` to be created by this mutation."""
+  location: LocationInput!
+}
+
+"""An input for mutations affecting \`Location\`"""
+input LocationInput {
+  id: UUID!
+}
+
+"""The output of our create \`Photo\` mutation."""
+type CreatePhotoPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Photo\` that was created by this mutation."""
+  photo: Photo
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our \`Photo\`. May be used by Relay 1."""
+  photoEdge(
+    """The method to use when ordering \`Photo\`."""
+    orderBy: [PhotosOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): PhotosEdge
+}
+
+"""All input for the create \`Photo\` mutation."""
+input CreatePhotoInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The \`Photo\` to be created by this mutation."""
+  photo: PhotoInput!
+}
+
+"""An input for mutations affecting \`Photo\`"""
+input PhotoInput {
+  id: UUID!
+}
+
+"""The output of our create \`Profile\` mutation."""
+type CreateProfilePayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Profile\` that was created by this mutation."""
+  profile: Profile
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our \`Profile\`. May be used by Relay 1."""
+  profileEdge(
+    """The method to use when ordering \`Profile\`."""
+    orderBy: [ProfilesOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): ProfilesEdge
+}
+
+"""All input for the create \`Profile\` mutation."""
+input CreateProfileInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The \`Profile\` to be created by this mutation."""
+  profile: ProfileInput!
+}
+
+"""An input for mutations affecting \`Profile\`"""
+input ProfileInput {
+  id: UUID!
 }
 
 """The output of our create \`User\` mutation."""
@@ -1578,6 +3250,240 @@ input MeasurementInput {
   key: String!
   value: Float
   userId: Int!
+}
+
+"""The output of our create \`Tag\` mutation."""
+type CreateTagPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Tag\` that was created by this mutation."""
+  tag: Tag
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our \`Tag\`. May be used by Relay 1."""
+  tagEdge(
+    """The method to use when ordering \`Tag\`."""
+    orderBy: [TagsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): TagsEdge
+}
+
+"""All input for the create \`Tag\` mutation."""
+input CreateTagInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The \`Tag\` to be created by this mutation."""
+  tag: TagInput!
+}
+
+"""An input for mutations affecting \`Tag\`"""
+input TagInput {
+  entityKind: EntityKinds!
+  entityId: UUID!
+  tag: String!
+}
+
+"""The output of our update \`Location\` mutation."""
+type UpdateLocationPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Location\` that was updated by this mutation."""
+  location: Location
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our \`Location\`. May be used by Relay 1."""
+  locationEdge(
+    """The method to use when ordering \`Location\`."""
+    orderBy: [LocationsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): LocationsEdge
+}
+
+"""All input for the \`updateLocation\` mutation."""
+input UpdateLocationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Location\` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the \`Location\` being updated.
+  """
+  locationPatch: LocationPatch!
+}
+
+"""
+Represents an update to a \`Location\`. Fields that are set will be updated.
+"""
+input LocationPatch {
+  id: UUID
+}
+
+"""All input for the \`updateLocationById\` mutation."""
+input UpdateLocationByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: UUID!
+
+  """
+  An object where the defined keys will be set on the \`Location\` being updated.
+  """
+  locationPatch: LocationPatch!
+}
+
+"""The output of our update \`Photo\` mutation."""
+type UpdatePhotoPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Photo\` that was updated by this mutation."""
+  photo: Photo
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our \`Photo\`. May be used by Relay 1."""
+  photoEdge(
+    """The method to use when ordering \`Photo\`."""
+    orderBy: [PhotosOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): PhotosEdge
+}
+
+"""All input for the \`updatePhoto\` mutation."""
+input UpdatePhotoInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Photo\` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the \`Photo\` being updated.
+  """
+  photoPatch: PhotoPatch!
+}
+
+"""
+Represents an update to a \`Photo\`. Fields that are set will be updated.
+"""
+input PhotoPatch {
+  id: UUID
+}
+
+"""All input for the \`updatePhotoById\` mutation."""
+input UpdatePhotoByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: UUID!
+
+  """
+  An object where the defined keys will be set on the \`Photo\` being updated.
+  """
+  photoPatch: PhotoPatch!
+}
+
+"""The output of our update \`Profile\` mutation."""
+type UpdateProfilePayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Profile\` that was updated by this mutation."""
+  profile: Profile
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our \`Profile\`. May be used by Relay 1."""
+  profileEdge(
+    """The method to use when ordering \`Profile\`."""
+    orderBy: [ProfilesOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): ProfilesEdge
+}
+
+"""All input for the \`updateProfile\` mutation."""
+input UpdateProfileInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Profile\` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the \`Profile\` being updated.
+  """
+  profilePatch: ProfilePatch!
+}
+
+"""
+Represents an update to a \`Profile\`. Fields that are set will be updated.
+"""
+input ProfilePatch {
+  id: UUID
+}
+
+"""All input for the \`updateProfileById\` mutation."""
+input UpdateProfileByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: UUID!
+
+  """
+  An object where the defined keys will be set on the \`Profile\` being updated.
+  """
+  profilePatch: ProfilePatch!
 }
 
 """The output of our update \`User\` mutation."""
@@ -1714,6 +3620,216 @@ input UpdateMeasurementByTimestampAndKeyInput {
   measurementPatch: MeasurementPatch!
 }
 
+"""The output of our update \`Tag\` mutation."""
+type UpdateTagPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Tag\` that was updated by this mutation."""
+  tag: Tag
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our \`Tag\`. May be used by Relay 1."""
+  tagEdge(
+    """The method to use when ordering \`Tag\`."""
+    orderBy: [TagsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): TagsEdge
+}
+
+"""All input for the \`updateTag\` mutation."""
+input UpdateTagInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Tag\` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the \`Tag\` being updated.
+  """
+  tagPatch: TagPatch!
+}
+
+"""Represents an update to a \`Tag\`. Fields that are set will be updated."""
+input TagPatch {
+  entityKind: EntityKinds
+  entityId: UUID
+  tag: String
+}
+
+"""All input for the \`updateTagByEntityKindAndEntityIdAndTag\` mutation."""
+input UpdateTagByEntityKindAndEntityIdAndTagInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  entityKind: EntityKinds!
+  entityId: UUID!
+  tag: String!
+
+  """
+  An object where the defined keys will be set on the \`Tag\` being updated.
+  """
+  tagPatch: TagPatch!
+}
+
+"""The output of our delete \`Location\` mutation."""
+type DeleteLocationPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Location\` that was deleted by this mutation."""
+  location: Location
+  deletedLocationId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our \`Location\`. May be used by Relay 1."""
+  locationEdge(
+    """The method to use when ordering \`Location\`."""
+    orderBy: [LocationsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): LocationsEdge
+}
+
+"""All input for the \`deleteLocation\` mutation."""
+input DeleteLocationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Location\` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""All input for the \`deleteLocationById\` mutation."""
+input DeleteLocationByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: UUID!
+}
+
+"""The output of our delete \`Photo\` mutation."""
+type DeletePhotoPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Photo\` that was deleted by this mutation."""
+  photo: Photo
+  deletedPhotoId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our \`Photo\`. May be used by Relay 1."""
+  photoEdge(
+    """The method to use when ordering \`Photo\`."""
+    orderBy: [PhotosOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): PhotosEdge
+}
+
+"""All input for the \`deletePhoto\` mutation."""
+input DeletePhotoInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Photo\` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""All input for the \`deletePhotoById\` mutation."""
+input DeletePhotoByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: UUID!
+}
+
+"""The output of our delete \`Profile\` mutation."""
+type DeleteProfilePayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Profile\` that was deleted by this mutation."""
+  profile: Profile
+  deletedProfileId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our \`Profile\`. May be used by Relay 1."""
+  profileEdge(
+    """The method to use when ordering \`Profile\`."""
+    orderBy: [ProfilesOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): ProfilesEdge
+}
+
+"""All input for the \`deleteProfile\` mutation."""
+input DeleteProfileInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Profile\` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""All input for the \`deleteProfileById\` mutation."""
+input DeleteProfileByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: UUID!
+}
+
 """The output of our delete \`User\` mutation."""
 type DeleteUserPayload {
   """
@@ -1812,6 +3928,56 @@ input DeleteMeasurementByTimestampAndKeyInput {
   clientMutationId: String
   timestamp: Datetime!
   key: String!
+}
+
+"""The output of our delete \`Tag\` mutation."""
+type DeleteTagPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Tag\` that was deleted by this mutation."""
+  tag: Tag
+  deletedTagId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our \`Tag\`. May be used by Relay 1."""
+  tagEdge(
+    """The method to use when ordering \`Tag\`."""
+    orderBy: [TagsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): TagsEdge
+}
+
+"""All input for the \`deleteTag\` mutation."""
+input DeleteTagInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Tag\` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""All input for the \`deleteTagByEntityKindAndEntityIdAndTag\` mutation."""
+input DeleteTagByEntityKindAndEntityIdAndTagInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  entityKind: EntityKinds!
+  entityId: UUID!
+  tag: String!
 }`;
 export const objects = {
   Query: {
@@ -1819,9 +3985,129 @@ export const objects = {
       return true;
     },
     plans: {
+      allLocations: {
+        plan() {
+          return connection(resource_locationsPgResource.find());
+        },
+        args: {
+          first(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          },
+          last(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          },
+          offset(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          },
+          before(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          },
+          after(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          },
+          condition(_condition, $connection, arg) {
+            const $select = $connection.getSubplan();
+            arg.apply($select, qbWhereBuilder);
+          },
+          orderBy(parent, $connection, value) {
+            const $select = $connection.getSubplan();
+            value.apply($select);
+          }
+        }
+      },
       allMeasurements: {
         plan() {
           return connection(resource_measurementsPgResource.find());
+        },
+        args: {
+          first(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          },
+          last(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          },
+          offset(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          },
+          before(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          },
+          after(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          },
+          condition(_condition, $connection, arg) {
+            const $select = $connection.getSubplan();
+            arg.apply($select, qbWhereBuilder);
+          },
+          orderBy(parent, $connection, value) {
+            const $select = $connection.getSubplan();
+            value.apply($select);
+          }
+        }
+      },
+      allPhotos: {
+        plan() {
+          return connection(resource_photosPgResource.find());
+        },
+        args: {
+          first(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          },
+          last(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          },
+          offset(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          },
+          before(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          },
+          after(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          },
+          condition(_condition, $connection, arg) {
+            const $select = $connection.getSubplan();
+            arg.apply($select, qbWhereBuilder);
+          },
+          orderBy(parent, $connection, value) {
+            const $select = $connection.getSubplan();
+            value.apply($select);
+          }
+        }
+      },
+      allProfiles: {
+        plan() {
+          return connection(resource_profilesPgResource.find());
+        },
+        args: {
+          first(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          },
+          last(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          },
+          offset(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          },
+          before(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          },
+          after(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          },
+          condition(_condition, $connection, arg) {
+            const $select = $connection.getSubplan();
+            arg.apply($select, qbWhereBuilder);
+          },
+          orderBy(parent, $connection, value) {
+            const $select = $connection.getSubplan();
+            value.apply($select);
+          }
+        }
+      },
+      allTags: {
+        plan() {
+          return connection(resource_tagsPgResource.find());
         },
         args: {
           first(_, $connection, arg) {
@@ -1879,6 +4165,17 @@ export const objects = {
           }
         }
       },
+      location(_$parent, args) {
+        const $nodeId = args.getRaw("nodeId");
+        return nodeFetcher_Location($nodeId);
+      },
+      locationById(_$root, {
+        $id
+      }) {
+        return resource_locationsPgResource.get({
+          id: $id
+        });
+      },
       measurement(_$parent, args) {
         const $nodeId = args.getRaw("nodeId");
         return nodeFetcher_Measurement($nodeId);
@@ -1899,8 +4196,45 @@ export const objects = {
         const specifier = nodeIdHandler_Query.plan($parent);
         return lambda(specifier, nodeIdCodecs[nodeIdHandler_Query.codec.name].encode);
       },
+      photo(_$parent, args) {
+        const $nodeId = args.getRaw("nodeId");
+        return nodeFetcher_Photo($nodeId);
+      },
+      photoById(_$root, {
+        $id
+      }) {
+        return resource_photosPgResource.get({
+          id: $id
+        });
+      },
+      profile(_$parent, args) {
+        const $nodeId = args.getRaw("nodeId");
+        return nodeFetcher_Profile($nodeId);
+      },
+      profileById(_$root, {
+        $id
+      }) {
+        return resource_profilesPgResource.get({
+          id: $id
+        });
+      },
       query() {
         return rootValue();
+      },
+      tag(_$parent, args) {
+        const $nodeId = args.getRaw("nodeId");
+        return nodeFetcher_Tag($nodeId);
+      },
+      tagByEntityKindAndEntityIdAndTag(_$root, {
+        $entityKind,
+        $entityId,
+        $tag
+      }) {
+        return resource_tagsPgResource.get({
+          entity_kind: $entityKind,
+          entity_id: $entityId,
+          tag: $tag
+        });
       },
       user(_$parent, args) {
         const $nodeId = args.getRaw("nodeId");
@@ -1918,9 +4252,69 @@ export const objects = {
   Mutation: {
     assertStep: __ValueStep,
     plans: {
+      createLocation: {
+        plan(_, args) {
+          const $insert = pgInsertSingle(resource_locationsPgResource, Object.create(null));
+          args.apply($insert);
+          const plan = object({
+            result: $insert
+          });
+          return plan;
+        },
+        args: {
+          input(_, $object) {
+            return $object;
+          }
+        }
+      },
       createMeasurement: {
         plan(_, args) {
           const $insert = pgInsertSingle(resource_measurementsPgResource, Object.create(null));
+          args.apply($insert);
+          const plan = object({
+            result: $insert
+          });
+          return plan;
+        },
+        args: {
+          input(_, $object) {
+            return $object;
+          }
+        }
+      },
+      createPhoto: {
+        plan(_, args) {
+          const $insert = pgInsertSingle(resource_photosPgResource, Object.create(null));
+          args.apply($insert);
+          const plan = object({
+            result: $insert
+          });
+          return plan;
+        },
+        args: {
+          input(_, $object) {
+            return $object;
+          }
+        }
+      },
+      createProfile: {
+        plan(_, args) {
+          const $insert = pgInsertSingle(resource_profilesPgResource, Object.create(null));
+          args.apply($insert);
+          const plan = object({
+            result: $insert
+          });
+          return plan;
+        },
+        args: {
+          input(_, $object) {
+            return $object;
+          }
+        }
+      },
+      createTag: {
+        plan(_, args) {
+          const $insert = pgInsertSingle(resource_tagsPgResource, Object.create(null));
           args.apply($insert);
           const plan = object({
             result: $insert
@@ -1948,6 +4342,36 @@ export const objects = {
           }
         }
       },
+      deleteLocation: {
+        plan(_$root, args) {
+          const $delete = pgDeleteSingle(resource_locationsPgResource, specFromArgs_Location2(args));
+          args.apply($delete);
+          return object({
+            result: $delete
+          });
+        },
+        args: {
+          input(_, $object) {
+            return $object;
+          }
+        }
+      },
+      deleteLocationById: {
+        plan(_$root, args) {
+          const $delete = pgDeleteSingle(resource_locationsPgResource, {
+            id: args.getRaw(['input', "id"])
+          });
+          args.apply($delete);
+          return object({
+            result: $delete
+          });
+        },
+        args: {
+          input(_, $object) {
+            return $object;
+          }
+        }
+      },
       deleteMeasurement: {
         plan(_$root, args) {
           const $delete = pgDeleteSingle(resource_measurementsPgResource, specFromArgs_Measurement2(args));
@@ -1967,6 +4391,98 @@ export const objects = {
           const $delete = pgDeleteSingle(resource_measurementsPgResource, {
             timestamp: args.getRaw(['input', "timestamp"]),
             key: args.getRaw(['input', "key"])
+          });
+          args.apply($delete);
+          return object({
+            result: $delete
+          });
+        },
+        args: {
+          input(_, $object) {
+            return $object;
+          }
+        }
+      },
+      deletePhoto: {
+        plan(_$root, args) {
+          const $delete = pgDeleteSingle(resource_photosPgResource, specFromArgs_Photo2(args));
+          args.apply($delete);
+          return object({
+            result: $delete
+          });
+        },
+        args: {
+          input(_, $object) {
+            return $object;
+          }
+        }
+      },
+      deletePhotoById: {
+        plan(_$root, args) {
+          const $delete = pgDeleteSingle(resource_photosPgResource, {
+            id: args.getRaw(['input', "id"])
+          });
+          args.apply($delete);
+          return object({
+            result: $delete
+          });
+        },
+        args: {
+          input(_, $object) {
+            return $object;
+          }
+        }
+      },
+      deleteProfile: {
+        plan(_$root, args) {
+          const $delete = pgDeleteSingle(resource_profilesPgResource, specFromArgs_Profile2(args));
+          args.apply($delete);
+          return object({
+            result: $delete
+          });
+        },
+        args: {
+          input(_, $object) {
+            return $object;
+          }
+        }
+      },
+      deleteProfileById: {
+        plan(_$root, args) {
+          const $delete = pgDeleteSingle(resource_profilesPgResource, {
+            id: args.getRaw(['input', "id"])
+          });
+          args.apply($delete);
+          return object({
+            result: $delete
+          });
+        },
+        args: {
+          input(_, $object) {
+            return $object;
+          }
+        }
+      },
+      deleteTag: {
+        plan(_$root, args) {
+          const $delete = pgDeleteSingle(resource_tagsPgResource, specFromArgs_Tag2(args));
+          args.apply($delete);
+          return object({
+            result: $delete
+          });
+        },
+        args: {
+          input(_, $object) {
+            return $object;
+          }
+        }
+      },
+      deleteTagByEntityKindAndEntityIdAndTag: {
+        plan(_$root, args) {
+          const $delete = pgDeleteSingle(resource_tagsPgResource, {
+            entity_kind: args.getRaw(['input', "entityKind"]),
+            entity_id: args.getRaw(['input', "entityId"]),
+            tag: args.getRaw(['input', "tag"])
           });
           args.apply($delete);
           return object({
@@ -2009,6 +4525,36 @@ export const objects = {
           }
         }
       },
+      updateLocation: {
+        plan(_$root, args) {
+          const $update = pgUpdateSingle(resource_locationsPgResource, specFromArgs_Location(args));
+          args.apply($update);
+          return object({
+            result: $update
+          });
+        },
+        args: {
+          input(_, $object) {
+            return $object;
+          }
+        }
+      },
+      updateLocationById: {
+        plan(_$root, args) {
+          const $update = pgUpdateSingle(resource_locationsPgResource, {
+            id: args.getRaw(['input', "id"])
+          });
+          args.apply($update);
+          return object({
+            result: $update
+          });
+        },
+        args: {
+          input(_, $object) {
+            return $object;
+          }
+        }
+      },
       updateMeasurement: {
         plan(_$root, args) {
           const $update = pgUpdateSingle(resource_measurementsPgResource, specFromArgs_Measurement(args));
@@ -2028,6 +4574,98 @@ export const objects = {
           const $update = pgUpdateSingle(resource_measurementsPgResource, {
             timestamp: args.getRaw(['input', "timestamp"]),
             key: args.getRaw(['input', "key"])
+          });
+          args.apply($update);
+          return object({
+            result: $update
+          });
+        },
+        args: {
+          input(_, $object) {
+            return $object;
+          }
+        }
+      },
+      updatePhoto: {
+        plan(_$root, args) {
+          const $update = pgUpdateSingle(resource_photosPgResource, specFromArgs_Photo(args));
+          args.apply($update);
+          return object({
+            result: $update
+          });
+        },
+        args: {
+          input(_, $object) {
+            return $object;
+          }
+        }
+      },
+      updatePhotoById: {
+        plan(_$root, args) {
+          const $update = pgUpdateSingle(resource_photosPgResource, {
+            id: args.getRaw(['input', "id"])
+          });
+          args.apply($update);
+          return object({
+            result: $update
+          });
+        },
+        args: {
+          input(_, $object) {
+            return $object;
+          }
+        }
+      },
+      updateProfile: {
+        plan(_$root, args) {
+          const $update = pgUpdateSingle(resource_profilesPgResource, specFromArgs_Profile(args));
+          args.apply($update);
+          return object({
+            result: $update
+          });
+        },
+        args: {
+          input(_, $object) {
+            return $object;
+          }
+        }
+      },
+      updateProfileById: {
+        plan(_$root, args) {
+          const $update = pgUpdateSingle(resource_profilesPgResource, {
+            id: args.getRaw(['input', "id"])
+          });
+          args.apply($update);
+          return object({
+            result: $update
+          });
+        },
+        args: {
+          input(_, $object) {
+            return $object;
+          }
+        }
+      },
+      updateTag: {
+        plan(_$root, args) {
+          const $update = pgUpdateSingle(resource_tagsPgResource, specFromArgs_Tag(args));
+          args.apply($update);
+          return object({
+            result: $update
+          });
+        },
+        args: {
+          input(_, $object) {
+            return $object;
+          }
+        }
+      },
+      updateTagByEntityKindAndEntityIdAndTag: {
+        plan(_$root, args) {
+          const $update = pgUpdateSingle(resource_tagsPgResource, {
+            entity_kind: args.getRaw(['input', "entityKind"]),
+            entity_id: args.getRaw(['input', "entityId"]),
+            tag: args.getRaw(['input', "tag"])
           });
           args.apply($update);
           return object({
@@ -2072,6 +4710,24 @@ export const objects = {
       }
     }
   },
+  CreateLocationPayload: {
+    assertStep: assertExecutableStep,
+    plans: {
+      clientMutationId($mutation) {
+        const $insert = $mutation.getStepForKey("result");
+        return $insert.getMeta("clientMutationId");
+      },
+      location($object) {
+        return $object.get("result");
+      },
+      locationEdge($mutation, fieldArgs) {
+        return pgMutationPayloadEdge(resource_locationsPgResource, locationsUniques[0].attributes, $mutation, fieldArgs);
+      },
+      query() {
+        return rootValue();
+      }
+    }
+  },
   CreateMeasurementPayload: {
     assertStep: assertExecutableStep,
     plans: {
@@ -2095,6 +4751,60 @@ export const objects = {
       }
     }
   },
+  CreatePhotoPayload: {
+    assertStep: assertExecutableStep,
+    plans: {
+      clientMutationId($mutation) {
+        const $insert = $mutation.getStepForKey("result");
+        return $insert.getMeta("clientMutationId");
+      },
+      photo($object) {
+        return $object.get("result");
+      },
+      photoEdge($mutation, fieldArgs) {
+        return pgMutationPayloadEdge(resource_photosPgResource, photosUniques[0].attributes, $mutation, fieldArgs);
+      },
+      query() {
+        return rootValue();
+      }
+    }
+  },
+  CreateProfilePayload: {
+    assertStep: assertExecutableStep,
+    plans: {
+      clientMutationId($mutation) {
+        const $insert = $mutation.getStepForKey("result");
+        return $insert.getMeta("clientMutationId");
+      },
+      profile($object) {
+        return $object.get("result");
+      },
+      profileEdge($mutation, fieldArgs) {
+        return pgMutationPayloadEdge(resource_profilesPgResource, profilesUniques[0].attributes, $mutation, fieldArgs);
+      },
+      query() {
+        return rootValue();
+      }
+    }
+  },
+  CreateTagPayload: {
+    assertStep: assertExecutableStep,
+    plans: {
+      clientMutationId($mutation) {
+        const $insert = $mutation.getStepForKey("result");
+        return $insert.getMeta("clientMutationId");
+      },
+      query() {
+        return rootValue();
+      },
+      tag($object) {
+        return $object.get("result");
+      },
+      tagEdge($mutation, fieldArgs) {
+        return pgMutationPayloadEdge(resource_tagsPgResource, tagsUniques[0].attributes, $mutation, fieldArgs);
+      }
+    }
+  },
   CreateUserPayload: {
     assertStep: assertExecutableStep,
     plans: {
@@ -2110,6 +4820,29 @@ export const objects = {
       },
       userEdge($mutation, fieldArgs) {
         return pgMutationPayloadEdge(resource_usersPgResource, usersUniques[0].attributes, $mutation, fieldArgs);
+      }
+    }
+  },
+  DeleteLocationPayload: {
+    assertStep: ObjectStep,
+    plans: {
+      clientMutationId($mutation) {
+        const $result = $mutation.getStepForKey("result");
+        return $result.getMeta("clientMutationId");
+      },
+      deletedLocationId($object) {
+        const $record = $object.getStepForKey("result");
+        const specifier = nodeIdHandler_Location.plan($record);
+        return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
+      },
+      location($object) {
+        return $object.get("result");
+      },
+      locationEdge($mutation, fieldArgs) {
+        return pgMutationPayloadEdge(resource_locationsPgResource, locationsUniques[0].attributes, $mutation, fieldArgs);
+      },
+      query() {
+        return rootValue();
       }
     }
   },
@@ -2141,6 +4874,75 @@ export const objects = {
       }
     }
   },
+  DeletePhotoPayload: {
+    assertStep: ObjectStep,
+    plans: {
+      clientMutationId($mutation) {
+        const $result = $mutation.getStepForKey("result");
+        return $result.getMeta("clientMutationId");
+      },
+      deletedPhotoId($object) {
+        const $record = $object.getStepForKey("result");
+        const specifier = nodeIdHandler_Photo.plan($record);
+        return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
+      },
+      photo($object) {
+        return $object.get("result");
+      },
+      photoEdge($mutation, fieldArgs) {
+        return pgMutationPayloadEdge(resource_photosPgResource, photosUniques[0].attributes, $mutation, fieldArgs);
+      },
+      query() {
+        return rootValue();
+      }
+    }
+  },
+  DeleteProfilePayload: {
+    assertStep: ObjectStep,
+    plans: {
+      clientMutationId($mutation) {
+        const $result = $mutation.getStepForKey("result");
+        return $result.getMeta("clientMutationId");
+      },
+      deletedProfileId($object) {
+        const $record = $object.getStepForKey("result");
+        const specifier = nodeIdHandler_Profile.plan($record);
+        return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
+      },
+      profile($object) {
+        return $object.get("result");
+      },
+      profileEdge($mutation, fieldArgs) {
+        return pgMutationPayloadEdge(resource_profilesPgResource, profilesUniques[0].attributes, $mutation, fieldArgs);
+      },
+      query() {
+        return rootValue();
+      }
+    }
+  },
+  DeleteTagPayload: {
+    assertStep: ObjectStep,
+    plans: {
+      clientMutationId($mutation) {
+        const $result = $mutation.getStepForKey("result");
+        return $result.getMeta("clientMutationId");
+      },
+      deletedTagId($object) {
+        const $record = $object.getStepForKey("result");
+        const specifier = nodeIdHandler_Tag.plan($record);
+        return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
+      },
+      query() {
+        return rootValue();
+      },
+      tag($object) {
+        return $object.get("result");
+      },
+      tagEdge($mutation, fieldArgs) {
+        return pgMutationPayloadEdge(resource_tagsPgResource, tagsUniques[0].attributes, $mutation, fieldArgs);
+      }
+    }
+  },
   DeleteUserPayload: {
     assertStep: ObjectStep,
     plans: {
@@ -2161,6 +4963,30 @@ export const objects = {
       },
       userEdge($mutation, fieldArgs) {
         return pgMutationPayloadEdge(resource_usersPgResource, usersUniques[0].attributes, $mutation, fieldArgs);
+      }
+    }
+  },
+  Location: {
+    assertStep: assertPgClassSingleStep,
+    plans: {
+      nodeId($parent) {
+        const specifier = nodeIdHandler_Location.plan($parent);
+        return lambda(specifier, nodeIdCodecs[nodeIdHandler_Location.codec.name].encode);
+      }
+    },
+    planType($specifier) {
+      const spec = Object.create(null);
+      for (const pkCol of locationsUniques[0].attributes) {
+        spec[pkCol] = get2($specifier, pkCol);
+      }
+      return resource_locationsPgResource.get(spec);
+    }
+  },
+  LocationsConnection: {
+    assertStep: ConnectionStep,
+    plans: {
+      totalCount($connection) {
+        return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint, false);
       }
     }
   },
@@ -2196,6 +5022,102 @@ export const objects = {
       }
     }
   },
+  Photo: {
+    assertStep: assertPgClassSingleStep,
+    plans: {
+      nodeId($parent) {
+        const specifier = nodeIdHandler_Photo.plan($parent);
+        return lambda(specifier, nodeIdCodecs[nodeIdHandler_Photo.codec.name].encode);
+      }
+    },
+    planType($specifier) {
+      const spec = Object.create(null);
+      for (const pkCol of photosUniques[0].attributes) {
+        spec[pkCol] = get2($specifier, pkCol);
+      }
+      return resource_photosPgResource.get(spec);
+    }
+  },
+  PhotosConnection: {
+    assertStep: ConnectionStep,
+    plans: {
+      totalCount($connection) {
+        return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint, false);
+      }
+    }
+  },
+  Profile: {
+    assertStep: assertPgClassSingleStep,
+    plans: {
+      nodeId($parent) {
+        const specifier = nodeIdHandler_Profile.plan($parent);
+        return lambda(specifier, nodeIdCodecs[nodeIdHandler_Profile.codec.name].encode);
+      }
+    },
+    planType($specifier) {
+      const spec = Object.create(null);
+      for (const pkCol of profilesUniques[0].attributes) {
+        spec[pkCol] = get2($specifier, pkCol);
+      }
+      return resource_profilesPgResource.get(spec);
+    }
+  },
+  ProfilesConnection: {
+    assertStep: ConnectionStep,
+    plans: {
+      totalCount($connection) {
+        return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint, false);
+      }
+    }
+  },
+  Tag: {
+    assertStep: assertPgClassSingleStep,
+    plans: {
+      entityId($record) {
+        return $record.get("entity_id");
+      },
+      entityKind($record) {
+        return $record.get("entity_kind");
+      },
+      nodeId($parent) {
+        const specifier = nodeIdHandler_Tag.plan($parent);
+        return lambda(specifier, nodeIdCodecs[nodeIdHandler_Tag.codec.name].encode);
+      }
+    },
+    planType($specifier) {
+      const spec = Object.create(null);
+      for (const pkCol of tagsUniques[0].attributes) {
+        spec[pkCol] = get2($specifier, pkCol);
+      }
+      return resource_tagsPgResource.get(spec);
+    }
+  },
+  TagsConnection: {
+    assertStep: ConnectionStep,
+    plans: {
+      totalCount($connection) {
+        return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint, false);
+      }
+    }
+  },
+  UpdateLocationPayload: {
+    assertStep: ObjectStep,
+    plans: {
+      clientMutationId($mutation) {
+        const $result = $mutation.getStepForKey("result");
+        return $result.getMeta("clientMutationId");
+      },
+      location($object) {
+        return $object.get("result");
+      },
+      locationEdge($mutation, fieldArgs) {
+        return pgMutationPayloadEdge(resource_locationsPgResource, locationsUniques[0].attributes, $mutation, fieldArgs);
+      },
+      query() {
+        return rootValue();
+      }
+    }
+  },
   UpdateMeasurementPayload: {
     assertStep: ObjectStep,
     plans: {
@@ -2216,6 +5138,60 @@ export const objects = {
         return resource_usersPgResource.get({
           id: $record.get("result").get("user_id")
         });
+      }
+    }
+  },
+  UpdatePhotoPayload: {
+    assertStep: ObjectStep,
+    plans: {
+      clientMutationId($mutation) {
+        const $result = $mutation.getStepForKey("result");
+        return $result.getMeta("clientMutationId");
+      },
+      photo($object) {
+        return $object.get("result");
+      },
+      photoEdge($mutation, fieldArgs) {
+        return pgMutationPayloadEdge(resource_photosPgResource, photosUniques[0].attributes, $mutation, fieldArgs);
+      },
+      query() {
+        return rootValue();
+      }
+    }
+  },
+  UpdateProfilePayload: {
+    assertStep: ObjectStep,
+    plans: {
+      clientMutationId($mutation) {
+        const $result = $mutation.getStepForKey("result");
+        return $result.getMeta("clientMutationId");
+      },
+      profile($object) {
+        return $object.get("result");
+      },
+      profileEdge($mutation, fieldArgs) {
+        return pgMutationPayloadEdge(resource_profilesPgResource, profilesUniques[0].attributes, $mutation, fieldArgs);
+      },
+      query() {
+        return rootValue();
+      }
+    }
+  },
+  UpdateTagPayload: {
+    assertStep: ObjectStep,
+    plans: {
+      clientMutationId($mutation) {
+        const $result = $mutation.getStepForKey("result");
+        return $result.getMeta("clientMutationId");
+      },
+      query() {
+        return rootValue();
+      },
+      tag($object) {
+        return $object.get("result");
+      },
+      tagEdge($mutation, fieldArgs) {
+        return pgMutationPayloadEdge(resource_tagsPgResource, tagsUniques[0].attributes, $mutation, fieldArgs);
       }
     }
   },
@@ -2315,12 +5291,60 @@ export const interfaces = {
   }
 };
 export const inputObjects = {
+  CreateLocationInput: {
+    plans: {
+      clientMutationId(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      },
+      location(qb, arg) {
+        if (arg != null) {
+          return qb.setBuilder();
+        }
+      }
+    }
+  },
   CreateMeasurementInput: {
     plans: {
       clientMutationId(qb, val) {
         qb.setMeta("clientMutationId", val);
       },
       measurement(qb, arg) {
+        if (arg != null) {
+          return qb.setBuilder();
+        }
+      }
+    }
+  },
+  CreatePhotoInput: {
+    plans: {
+      clientMutationId(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      },
+      photo(qb, arg) {
+        if (arg != null) {
+          return qb.setBuilder();
+        }
+      }
+    }
+  },
+  CreateProfileInput: {
+    plans: {
+      clientMutationId(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      },
+      profile(qb, arg) {
+        if (arg != null) {
+          return qb.setBuilder();
+        }
+      }
+    }
+  },
+  CreateTagInput: {
+    plans: {
+      clientMutationId(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      },
+      tag(qb, arg) {
         if (arg != null) {
           return qb.setBuilder();
         }
@@ -2339,6 +5363,20 @@ export const inputObjects = {
       }
     }
   },
+  DeleteLocationByIdInput: {
+    plans: {
+      clientMutationId(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      }
+    }
+  },
+  DeleteLocationInput: {
+    plans: {
+      clientMutationId(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      }
+    }
+  },
   DeleteMeasurementByTimestampAndKeyInput: {
     plans: {
       clientMutationId(qb, val) {
@@ -2347,6 +5385,48 @@ export const inputObjects = {
     }
   },
   DeleteMeasurementInput: {
+    plans: {
+      clientMutationId(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      }
+    }
+  },
+  DeletePhotoByIdInput: {
+    plans: {
+      clientMutationId(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      }
+    }
+  },
+  DeletePhotoInput: {
+    plans: {
+      clientMutationId(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      }
+    }
+  },
+  DeleteProfileByIdInput: {
+    plans: {
+      clientMutationId(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      }
+    }
+  },
+  DeleteProfileInput: {
+    plans: {
+      clientMutationId(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      }
+    }
+  },
+  DeleteTagByEntityKindAndEntityIdAndTagInput: {
+    plans: {
+      clientMutationId(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      }
+    }
+  },
+  DeleteTagInput: {
     plans: {
       clientMutationId(qb, val) {
         qb.setMeta("clientMutationId", val);
@@ -2364,6 +5444,41 @@ export const inputObjects = {
     plans: {
       clientMutationId(qb, val) {
         qb.setMeta("clientMutationId", val);
+      }
+    }
+  },
+  LocationCondition: {
+    plans: {
+      id($condition, val) {
+        $condition.where({
+          type: "attribute",
+          attribute: "id",
+          callback(expression) {
+            return val === null ? sql`${expression} is null` : sql`${expression} = ${sqlValueWithCodec(val, TYPES.uuid)}`;
+          }
+        });
+      }
+    }
+  },
+  LocationInput: {
+    baked: createObjectAndApplyChildren,
+    plans: {
+      id(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("id", bakedInputRuntime(schema, field.type, val));
+      }
+    }
+  },
+  LocationPatch: {
+    baked: createObjectAndApplyChildren,
+    plans: {
+      id(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("id", bakedInputRuntime(schema, field.type, val));
       }
     }
   },
@@ -2465,6 +5580,177 @@ export const inputObjects = {
       }
     }
   },
+  PhotoCondition: {
+    plans: {
+      id($condition, val) {
+        $condition.where({
+          type: "attribute",
+          attribute: "id",
+          callback(expression) {
+            return val === null ? sql`${expression} is null` : sql`${expression} = ${sqlValueWithCodec(val, TYPES.uuid)}`;
+          }
+        });
+      }
+    }
+  },
+  PhotoInput: {
+    baked: createObjectAndApplyChildren,
+    plans: {
+      id(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("id", bakedInputRuntime(schema, field.type, val));
+      }
+    }
+  },
+  PhotoPatch: {
+    baked: createObjectAndApplyChildren,
+    plans: {
+      id(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("id", bakedInputRuntime(schema, field.type, val));
+      }
+    }
+  },
+  ProfileCondition: {
+    plans: {
+      id($condition, val) {
+        $condition.where({
+          type: "attribute",
+          attribute: "id",
+          callback(expression) {
+            return val === null ? sql`${expression} is null` : sql`${expression} = ${sqlValueWithCodec(val, TYPES.uuid)}`;
+          }
+        });
+      }
+    }
+  },
+  ProfileInput: {
+    baked: createObjectAndApplyChildren,
+    plans: {
+      id(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("id", bakedInputRuntime(schema, field.type, val));
+      }
+    }
+  },
+  ProfilePatch: {
+    baked: createObjectAndApplyChildren,
+    plans: {
+      id(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("id", bakedInputRuntime(schema, field.type, val));
+      }
+    }
+  },
+  TagCondition: {
+    plans: {
+      entityId($condition, val) {
+        $condition.where({
+          type: "attribute",
+          attribute: "entity_id",
+          callback(expression) {
+            return val === null ? sql`${expression} is null` : sql`${expression} = ${sqlValueWithCodec(val, TYPES.uuid)}`;
+          }
+        });
+      },
+      entityKind($condition, val) {
+        $condition.where({
+          type: "attribute",
+          attribute: "entity_kind",
+          callback(expression) {
+            return val === null ? sql`${expression} is null` : sql`${expression} = ${sqlValueWithCodec(val, spec_locationTags_attributes_entity_kind_codec_EntityKindsEnum)}`;
+          }
+        });
+      },
+      tag($condition, val) {
+        $condition.where({
+          type: "attribute",
+          attribute: "tag",
+          callback(expression) {
+            return val === null ? sql`${expression} is null` : sql`${expression} = ${sqlValueWithCodec(val, TYPES.citext)}`;
+          }
+        });
+      }
+    }
+  },
+  TagInput: {
+    baked: createObjectAndApplyChildren,
+    plans: {
+      entityId(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("entity_id", bakedInputRuntime(schema, field.type, val));
+      },
+      entityKind(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("entity_kind", bakedInputRuntime(schema, field.type, val));
+      },
+      tag(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("tag", bakedInputRuntime(schema, field.type, val));
+      }
+    }
+  },
+  TagPatch: {
+    baked: createObjectAndApplyChildren,
+    plans: {
+      entityId(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("entity_id", bakedInputRuntime(schema, field.type, val));
+      },
+      entityKind(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("entity_kind", bakedInputRuntime(schema, field.type, val));
+      },
+      tag(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("tag", bakedInputRuntime(schema, field.type, val));
+      }
+    }
+  },
+  UpdateLocationByIdInput: {
+    plans: {
+      clientMutationId(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      },
+      locationPatch(qb, arg) {
+        if (arg != null) {
+          return qb.setBuilder();
+        }
+      }
+    }
+  },
+  UpdateLocationInput: {
+    plans: {
+      clientMutationId(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      },
+      locationPatch(qb, arg) {
+        if (arg != null) {
+          return qb.setBuilder();
+        }
+      }
+    }
+  },
   UpdateMeasurementByTimestampAndKeyInput: {
     plans: {
       clientMutationId(qb, val) {
@@ -2483,6 +5769,78 @@ export const inputObjects = {
         qb.setMeta("clientMutationId", val);
       },
       measurementPatch(qb, arg) {
+        if (arg != null) {
+          return qb.setBuilder();
+        }
+      }
+    }
+  },
+  UpdatePhotoByIdInput: {
+    plans: {
+      clientMutationId(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      },
+      photoPatch(qb, arg) {
+        if (arg != null) {
+          return qb.setBuilder();
+        }
+      }
+    }
+  },
+  UpdatePhotoInput: {
+    plans: {
+      clientMutationId(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      },
+      photoPatch(qb, arg) {
+        if (arg != null) {
+          return qb.setBuilder();
+        }
+      }
+    }
+  },
+  UpdateProfileByIdInput: {
+    plans: {
+      clientMutationId(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      },
+      profilePatch(qb, arg) {
+        if (arg != null) {
+          return qb.setBuilder();
+        }
+      }
+    }
+  },
+  UpdateProfileInput: {
+    plans: {
+      clientMutationId(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      },
+      profilePatch(qb, arg) {
+        if (arg != null) {
+          return qb.setBuilder();
+        }
+      }
+    }
+  },
+  UpdateTagByEntityKindAndEntityIdAndTagInput: {
+    plans: {
+      clientMutationId(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      },
+      tagPatch(qb, arg) {
+        if (arg != null) {
+          return qb.setBuilder();
+        }
+      }
+    }
+  },
+  UpdateTagInput: {
+    plans: {
+      clientMutationId(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      },
+      tagPatch(qb, arg) {
         if (arg != null) {
           return qb.setBuilder();
         }
@@ -2572,8 +5930,8 @@ export const inputObjects = {
 };
 export const scalars = {
   Cursor: {
-    serialize: DatetimeSerialize,
-    parseValue: DatetimeSerialize,
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
     parseLiteral(ast) {
       if (ast.kind !== Kind.STRING) {
         throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
@@ -2582,17 +5940,79 @@ export const scalars = {
     }
   },
   Datetime: {
-    serialize: DatetimeSerialize,
-    parseValue: DatetimeSerialize,
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
     parseLiteral(ast) {
       if (ast.kind !== Kind.STRING) {
         throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
       }
       return ast.value;
     }
+  },
+  UUID: {
+    serialize: UUIDSerialize,
+    parseValue(value) {
+      return coerce("" + value);
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // ERRORS: add name to this error
+        throw new GraphQLError(`${"UUID" ?? "This scalar"} can only parse string values (kind = '${ast.kind}')`);
+      }
+      return coerce(ast.value);
+    }
   }
 };
 export const enums = {
+  EntityKinds: {
+    values: {
+      LOCATIONS: {
+        value: "locations"
+      },
+      PHOTOS: {
+        value: "photos"
+      },
+      PROFILES: {
+        value: "profiles"
+      }
+    }
+  },
+  LocationsOrderBy: {
+    values: {
+      ID_ASC(queryBuilder) {
+        queryBuilder.orderBy({
+          attribute: "id",
+          direction: "ASC"
+        });
+        queryBuilder.setOrderIsUnique();
+      },
+      ID_DESC(queryBuilder) {
+        queryBuilder.orderBy({
+          attribute: "id",
+          direction: "DESC"
+        });
+        queryBuilder.setOrderIsUnique();
+      },
+      PRIMARY_KEY_ASC(queryBuilder) {
+        locationsUniques[0].attributes.forEach(attributeName => {
+          queryBuilder.orderBy({
+            attribute: attributeName,
+            direction: "ASC"
+          });
+        });
+        queryBuilder.setOrderIsUnique();
+      },
+      PRIMARY_KEY_DESC(queryBuilder) {
+        locationsUniques[0].attributes.forEach(attributeName => {
+          queryBuilder.orderBy({
+            attribute: attributeName,
+            direction: "DESC"
+          });
+        });
+        queryBuilder.setOrderIsUnique();
+      }
+    }
+  },
   MeasurementsOrderBy: {
     values: {
       KEY_ASC(queryBuilder) {
@@ -2660,6 +6080,138 @@ export const enums = {
       VALUE_DESC(queryBuilder) {
         queryBuilder.orderBy({
           attribute: "value",
+          direction: "DESC"
+        });
+      }
+    }
+  },
+  PhotosOrderBy: {
+    values: {
+      ID_ASC(queryBuilder) {
+        queryBuilder.orderBy({
+          attribute: "id",
+          direction: "ASC"
+        });
+        queryBuilder.setOrderIsUnique();
+      },
+      ID_DESC(queryBuilder) {
+        queryBuilder.orderBy({
+          attribute: "id",
+          direction: "DESC"
+        });
+        queryBuilder.setOrderIsUnique();
+      },
+      PRIMARY_KEY_ASC(queryBuilder) {
+        photosUniques[0].attributes.forEach(attributeName => {
+          queryBuilder.orderBy({
+            attribute: attributeName,
+            direction: "ASC"
+          });
+        });
+        queryBuilder.setOrderIsUnique();
+      },
+      PRIMARY_KEY_DESC(queryBuilder) {
+        photosUniques[0].attributes.forEach(attributeName => {
+          queryBuilder.orderBy({
+            attribute: attributeName,
+            direction: "DESC"
+          });
+        });
+        queryBuilder.setOrderIsUnique();
+      }
+    }
+  },
+  ProfilesOrderBy: {
+    values: {
+      ID_ASC(queryBuilder) {
+        queryBuilder.orderBy({
+          attribute: "id",
+          direction: "ASC"
+        });
+        queryBuilder.setOrderIsUnique();
+      },
+      ID_DESC(queryBuilder) {
+        queryBuilder.orderBy({
+          attribute: "id",
+          direction: "DESC"
+        });
+        queryBuilder.setOrderIsUnique();
+      },
+      PRIMARY_KEY_ASC(queryBuilder) {
+        profilesUniques[0].attributes.forEach(attributeName => {
+          queryBuilder.orderBy({
+            attribute: attributeName,
+            direction: "ASC"
+          });
+        });
+        queryBuilder.setOrderIsUnique();
+      },
+      PRIMARY_KEY_DESC(queryBuilder) {
+        profilesUniques[0].attributes.forEach(attributeName => {
+          queryBuilder.orderBy({
+            attribute: attributeName,
+            direction: "DESC"
+          });
+        });
+        queryBuilder.setOrderIsUnique();
+      }
+    }
+  },
+  TagsOrderBy: {
+    values: {
+      ENTITY_ID_ASC(queryBuilder) {
+        queryBuilder.orderBy({
+          attribute: "entity_id",
+          direction: "ASC"
+        });
+      },
+      ENTITY_ID_DESC(queryBuilder) {
+        queryBuilder.orderBy({
+          attribute: "entity_id",
+          direction: "DESC"
+        });
+      },
+      ENTITY_KIND_ASC(queryBuilder) {
+        queryBuilder.orderBy({
+          attribute: "entity_kind",
+          direction: "ASC"
+        });
+        queryBuilder.setOrderIsUnique();
+      },
+      ENTITY_KIND_DESC(queryBuilder) {
+        queryBuilder.orderBy({
+          attribute: "entity_kind",
+          direction: "DESC"
+        });
+        queryBuilder.setOrderIsUnique();
+      },
+      PRIMARY_KEY_ASC(queryBuilder) {
+        tagsUniques[0].attributes.forEach(attributeName => {
+          queryBuilder.orderBy({
+            attribute: attributeName,
+            direction: "ASC"
+          });
+        });
+        queryBuilder.setOrderIsUnique();
+      },
+      PRIMARY_KEY_DESC(queryBuilder) {
+        tagsUniques[0].attributes.forEach(attributeName => {
+          queryBuilder.orderBy({
+            attribute: attributeName,
+            direction: "DESC"
+          });
+        });
+        queryBuilder.setOrderIsUnique();
+      },
+      TAG_ASC(queryBuilder) {
+        queryBuilder.orderBy({
+          attribute: "tag",
+          direction: "ASC"
+        });
+      },
+      TAG_DESC(queryBuilder) {
+        queryBuilder.orderBy({
+          attribute: "tag",
           direction: "DESC"
         });
       }

--- a/postgraphile/postgraphile/__tests__/schema/v4/partitions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/partitions.1.export.mjs
@@ -680,7 +680,8 @@ const tagsCodec = recordCodec({
       name: "tags"
     },
     tags: {
-      __proto__: null
+      __proto__: null,
+      partitionExpose: "child"
     }
   },
   executor: executor
@@ -879,23 +880,22 @@ const registryConfig_pgResources_measurements_measurements = {
     tags: {}
   }
 };
-const tagsUniques = [{
-  isPrimary: true,
-  attributes: ["entity_kind", "entity_id", "tag"],
-  description: undefined,
-  extensions: {
-    tags: {
-      __proto__: null
-    }
-  }
-}];
 const registryConfig_pgResources_tags_tags = {
   executor: executor,
   name: "tags",
   identifier: "main.partitions.tags",
   from: tagsIdentifier,
   codec: tagsCodec,
-  uniques: tagsUniques,
+  uniques: [{
+    isPrimary: true,
+    attributes: ["entity_kind", "entity_id", "tag"],
+    description: undefined,
+    extensions: {
+      tags: {
+        __proto__: null
+      }
+    }
+  }],
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -909,7 +909,9 @@ const registryConfig_pgResources_tags_tags = {
     isUpdatable: true,
     isDeletable: true,
     hasPartitions: true,
-    tags: {}
+    tags: {
+      partitionExpose: "child"
+    }
   }
 };
 const registryConfig_pgResources_measurements_y2022_measurements_y2022 = {
@@ -1017,22 +1019,23 @@ const registryConfig_pgResources_measurements_y2024_measurements_y2024 = {
     tags: {}
   }
 };
+const location_tagsUniques = [{
+  isPrimary: true,
+  attributes: ["entity_kind", "entity_id", "tag"],
+  description: undefined,
+  extensions: {
+    tags: {
+      __proto__: null
+    }
+  }
+}];
 const registryConfig_pgResources_location_tags_location_tags = {
   executor: executor,
   name: "location_tags",
   identifier: "main.partitions.location_tags",
   from: locationTagsIdentifier,
   codec: locationTagsCodec,
-  uniques: [{
-    isPrimary: true,
-    attributes: ["entity_kind", "entity_id", "tag"],
-    description: undefined,
-    extensions: {
-      tags: {
-        __proto__: null
-      }
-    }
-  }],
+  uniques: location_tagsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -1052,22 +1055,23 @@ const registryConfig_pgResources_location_tags_location_tags = {
     tags: {}
   }
 };
+const photo_tagsUniques = [{
+  isPrimary: true,
+  attributes: ["entity_kind", "entity_id", "tag"],
+  description: undefined,
+  extensions: {
+    tags: {
+      __proto__: null
+    }
+  }
+}];
 const registryConfig_pgResources_photo_tags_photo_tags = {
   executor: executor,
   name: "photo_tags",
   identifier: "main.partitions.photo_tags",
   from: photoTagsIdentifier,
   codec: photoTagsCodec,
-  uniques: [{
-    isPrimary: true,
-    attributes: ["entity_kind", "entity_id", "tag"],
-    description: undefined,
-    extensions: {
-      tags: {
-        __proto__: null
-      }
-    }
-  }],
+  uniques: photo_tagsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -1087,22 +1091,23 @@ const registryConfig_pgResources_photo_tags_photo_tags = {
     tags: {}
   }
 };
+const profile_tagsUniques = [{
+  isPrimary: true,
+  attributes: ["entity_kind", "entity_id", "tag"],
+  description: undefined,
+  extensions: {
+    tags: {
+      __proto__: null
+    }
+  }
+}];
 const registryConfig_pgResources_profile_tags_profile_tags = {
   executor: executor,
   name: "profile_tags",
   identifier: "main.partitions.profile_tags",
   from: profileTagsIdentifier,
   codec: profileTagsCodec,
-  uniques: [{
-    isPrimary: true,
-    attributes: ["entity_kind", "entity_id", "tag"],
-    description: undefined,
-    extensions: {
-      tags: {
-        __proto__: null
-      }
-    }
-  }],
+  uniques: profile_tagsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -1840,7 +1845,9 @@ const resource_photosPgResource = registry.pgResources["photos"];
 const resource_profilesPgResource = registry.pgResources["profiles"];
 const resource_usersPgResource = registry.pgResources["users"];
 const resource_measurementsPgResource = registry.pgResources["measurements"];
-const resource_tagsPgResource = registry.pgResources["tags"];
+const resource_location_tagsPgResource = registry.pgResources["location_tags"];
+const resource_photo_tagsPgResource = registry.pgResources["photo_tags"];
+const resource_profile_tagsPgResource = registry.pgResources["profile_tags"];
 const nodeIdHandler_Location = {
   typeName: "Location",
   codec: nodeIdCodecs_base64JSON_base64JSON,
@@ -1997,12 +2004,12 @@ const nodeFetcher_Measurement = $nodeId => {
   const $decoded = lambda($nodeId, specForHandler(nodeIdHandler_Measurement));
   return nodeIdHandler_Measurement.get(nodeIdHandler_Measurement.getSpec($decoded));
 };
-const nodeIdHandler_Tag = {
-  typeName: "Tag",
+const nodeIdHandler_LocationTag = {
+  typeName: "LocationTag",
   codec: nodeIdCodecs_base64JSON_base64JSON,
   deprecationReason: undefined,
   plan($record) {
-    return list([constant("tags", false), $record.get("entity_kind"), $record.get("entity_id"), $record.get("tag")]);
+    return list([constant("location_tags", false), $record.get("entity_kind"), $record.get("entity_id"), $record.get("tag")]);
   },
   getSpec($list) {
     return {
@@ -2015,15 +2022,71 @@ const nodeIdHandler_Tag = {
     return value.slice(1);
   },
   get(spec) {
-    return resource_tagsPgResource.get(spec);
+    return resource_location_tagsPgResource.get(spec);
   },
   match(obj) {
-    return obj[0] === "tags";
+    return obj[0] === "location_tags";
   }
 };
-const nodeFetcher_Tag = $nodeId => {
-  const $decoded = lambda($nodeId, specForHandler(nodeIdHandler_Tag));
-  return nodeIdHandler_Tag.get(nodeIdHandler_Tag.getSpec($decoded));
+const nodeFetcher_LocationTag = $nodeId => {
+  const $decoded = lambda($nodeId, specForHandler(nodeIdHandler_LocationTag));
+  return nodeIdHandler_LocationTag.get(nodeIdHandler_LocationTag.getSpec($decoded));
+};
+const nodeIdHandler_PhotoTag = {
+  typeName: "PhotoTag",
+  codec: nodeIdCodecs_base64JSON_base64JSON,
+  deprecationReason: undefined,
+  plan($record) {
+    return list([constant("photo_tags", false), $record.get("entity_kind"), $record.get("entity_id"), $record.get("tag")]);
+  },
+  getSpec($list) {
+    return {
+      entity_kind: inhibitOnNull(access($list, [1])),
+      entity_id: inhibitOnNull(access($list, [2])),
+      tag: inhibitOnNull(access($list, [3]))
+    };
+  },
+  getIdentifiers(value) {
+    return value.slice(1);
+  },
+  get(spec) {
+    return resource_photo_tagsPgResource.get(spec);
+  },
+  match(obj) {
+    return obj[0] === "photo_tags";
+  }
+};
+const nodeFetcher_PhotoTag = $nodeId => {
+  const $decoded = lambda($nodeId, specForHandler(nodeIdHandler_PhotoTag));
+  return nodeIdHandler_PhotoTag.get(nodeIdHandler_PhotoTag.getSpec($decoded));
+};
+const nodeIdHandler_ProfileTag = {
+  typeName: "ProfileTag",
+  codec: nodeIdCodecs_base64JSON_base64JSON,
+  deprecationReason: undefined,
+  plan($record) {
+    return list([constant("profile_tags", false), $record.get("entity_kind"), $record.get("entity_id"), $record.get("tag")]);
+  },
+  getSpec($list) {
+    return {
+      entity_kind: inhibitOnNull(access($list, [1])),
+      entity_id: inhibitOnNull(access($list, [2])),
+      tag: inhibitOnNull(access($list, [3]))
+    };
+  },
+  getIdentifiers(value) {
+    return value.slice(1);
+  },
+  get(spec) {
+    return resource_profile_tagsPgResource.get(spec);
+  },
+  match(obj) {
+    return obj[0] === "profile_tags";
+  }
+};
+const nodeFetcher_ProfileTag = $nodeId => {
+  const $decoded = lambda($nodeId, specForHandler(nodeIdHandler_ProfileTag));
+  return nodeIdHandler_ProfileTag.get(nodeIdHandler_ProfileTag.getSpec($decoded));
 };
 function qbWhereBuilder(qb) {
   return qb.whereBuilder();
@@ -2036,7 +2099,9 @@ const nodeIdHandlerByTypeName = {
   Profile: nodeIdHandler_Profile,
   User: nodeIdHandler_User,
   Measurement: nodeIdHandler_Measurement,
-  Tag: nodeIdHandler_Tag
+  LocationTag: nodeIdHandler_LocationTag,
+  PhotoTag: nodeIdHandler_PhotoTag,
+  ProfileTag: nodeIdHandler_ProfileTag
 };
 const decodeNodeId = makeDecodeNodeId(Object.values(nodeIdHandlerByTypeName));
 function findTypeNameMatch(specifier) {
@@ -2078,9 +2143,17 @@ const specFromArgs_Measurement = args => {
   const $nodeId = args.getRaw(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandler_Measurement, $nodeId);
 };
-const specFromArgs_Tag = args => {
+const specFromArgs_LocationTag = args => {
   const $nodeId = args.getRaw(["input", "nodeId"]);
-  return specFromNodeId(nodeIdHandler_Tag, $nodeId);
+  return specFromNodeId(nodeIdHandler_LocationTag, $nodeId);
+};
+const specFromArgs_PhotoTag = args => {
+  const $nodeId = args.getRaw(["input", "nodeId"]);
+  return specFromNodeId(nodeIdHandler_PhotoTag, $nodeId);
+};
+const specFromArgs_ProfileTag = args => {
+  const $nodeId = args.getRaw(["input", "nodeId"]);
+  return specFromNodeId(nodeIdHandler_ProfileTag, $nodeId);
 };
 const specFromArgs_Location2 = args => {
   const $nodeId = args.getRaw(["input", "nodeId"]);
@@ -2102,9 +2175,17 @@ const specFromArgs_Measurement2 = args => {
   const $nodeId = args.getRaw(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandler_Measurement, $nodeId);
 };
-const specFromArgs_Tag2 = args => {
+const specFromArgs_LocationTag2 = args => {
   const $nodeId = args.getRaw(["input", "nodeId"]);
-  return specFromNodeId(nodeIdHandler_Tag, $nodeId);
+  return specFromNodeId(nodeIdHandler_LocationTag, $nodeId);
+};
+const specFromArgs_PhotoTag2 = args => {
+  const $nodeId = args.getRaw(["input", "nodeId"]);
+  return specFromNodeId(nodeIdHandler_PhotoTag, $nodeId);
+};
+const specFromArgs_ProfileTag2 = args => {
+  const $nodeId = args.getRaw(["input", "nodeId"]);
+  return specFromNodeId(nodeIdHandler_ProfileTag, $nodeId);
 };
 const getPgSelectSingleFromMutationResult = (resource, pkAttributes, $mutation) => {
   const $result = $mutation.getStepForKey("result", true);
@@ -2160,8 +2241,14 @@ type Query implements Node {
   """Get a single \`Measurement\`."""
   measurementByTimestampAndKey(timestamp: Datetime!, key: String!): Measurement
 
-  """Get a single \`Tag\`."""
-  tagByEntityKindAndEntityIdAndTag(entityKind: EntityKinds!, entityId: UUID!, tag: String!): Tag
+  """Get a single \`LocationTag\`."""
+  locationTagByEntityKindAndEntityIdAndTag(entityKind: EntityKinds!, entityId: UUID!, tag: String!): LocationTag
+
+  """Get a single \`PhotoTag\`."""
+  photoTagByEntityKindAndEntityIdAndTag(entityKind: EntityKinds!, entityId: UUID!, tag: String!): PhotoTag
+
+  """Get a single \`ProfileTag\`."""
+  profileTagByEntityKindAndEntityIdAndTag(entityKind: EntityKinds!, entityId: UUID!, tag: String!): ProfileTag
 
   """Reads a single \`Location\` using its globally unique \`ID\`."""
   location(
@@ -2195,11 +2282,27 @@ type Query implements Node {
     nodeId: ID!
   ): Measurement
 
-  """Reads a single \`Tag\` using its globally unique \`ID\`."""
-  tag(
-    """The globally unique \`ID\` to be used in selecting a single \`Tag\`."""
+  """Reads a single \`LocationTag\` using its globally unique \`ID\`."""
+  locationTag(
+    """
+    The globally unique \`ID\` to be used in selecting a single \`LocationTag\`.
+    """
     nodeId: ID!
-  ): Tag
+  ): LocationTag
+
+  """Reads a single \`PhotoTag\` using its globally unique \`ID\`."""
+  photoTag(
+    """The globally unique \`ID\` to be used in selecting a single \`PhotoTag\`."""
+    nodeId: ID!
+  ): PhotoTag
+
+  """Reads a single \`ProfileTag\` using its globally unique \`ID\`."""
+  profileTag(
+    """
+    The globally unique \`ID\` to be used in selecting a single \`ProfileTag\`.
+    """
+    nodeId: ID!
+  ): ProfileTag
 
   """Reads and enables pagination through a set of \`Location\`."""
   allLocations(
@@ -2346,8 +2449,8 @@ type Query implements Node {
     orderBy: [MeasurementsOrderBy!] = [PRIMARY_KEY_ASC]
   ): MeasurementsConnection
 
-  """Reads and enables pagination through a set of \`Tag\`."""
-  allTags(
+  """Reads and enables pagination through a set of \`LocationTag\`."""
+  allLocationTags(
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -2369,11 +2472,69 @@ type Query implements Node {
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: TagCondition
+    condition: LocationTagCondition
 
-    """The method to use when ordering \`Tag\`."""
-    orderBy: [TagsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): TagsConnection
+    """The method to use when ordering \`LocationTag\`."""
+    orderBy: [LocationTagsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LocationTagsConnection
+
+  """Reads and enables pagination through a set of \`PhotoTag\`."""
+  allPhotoTags(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PhotoTagCondition
+
+    """The method to use when ordering \`PhotoTag\`."""
+    orderBy: [PhotoTagsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PhotoTagsConnection
+
+  """Reads and enables pagination through a set of \`ProfileTag\`."""
+  allProfileTags(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProfileTagCondition
+
+    """The method to use when ordering \`ProfileTag\`."""
+    orderBy: [ProfileTagsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProfileTagsConnection
 }
 
 """An object with a globally unique \`ID\`."""
@@ -2390,6 +2551,35 @@ type Location implements Node {
   """
   nodeId: ID!
   id: UUID!
+
+  """Reads and enables pagination through a set of \`LocationTag\`."""
+  locationTagsByEntityId(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: LocationTagCondition
+
+    """The method to use when ordering \`LocationTag\`."""
+    orderBy: [LocationTagsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LocationTagsConnection!
 }
 
 """
@@ -2397,12 +2587,199 @@ A universally unique identifier as defined by [RFC 4122](https://tools.ietf.org/
 """
 scalar UUID
 
+"""A connection to a list of \`LocationTag\` values."""
+type LocationTagsConnection {
+  """A list of \`LocationTag\` objects."""
+  nodes: [LocationTag]!
+
+  """
+  A list of edges which contains the \`LocationTag\` and cursor to aid in pagination.
+  """
+  edges: [LocationTagsEdge]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`LocationTag\` you could get from the connection."""
+  totalCount: Int!
+}
+
+type LocationTag implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  entityKind: EntityKinds!
+  entityId: UUID!
+  tag: String!
+
+  """Reads a single \`Location\` that is related to this \`LocationTag\`."""
+  locationByEntityId: Location
+}
+
+enum EntityKinds {
+  PHOTOS
+  LOCATIONS
+  PROFILES
+}
+
+"""A \`LocationTag\` edge in the connection."""
+type LocationTagsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`LocationTag\` at the end of the edge."""
+  node: LocationTag
+}
+
+"""A location in a connection that can be used for resuming pagination."""
+scalar Cursor
+
+"""Information about pagination in a connection."""
+type PageInfo {
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: Cursor
+
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+}
+
+"""
+A condition to be used against \`LocationTag\` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input LocationTagCondition {
+  """Checks for equality with the object’s \`entityKind\` field."""
+  entityKind: EntityKinds
+
+  """Checks for equality with the object’s \`entityId\` field."""
+  entityId: UUID
+
+  """Checks for equality with the object’s \`tag\` field."""
+  tag: String
+}
+
+"""Methods to use when ordering \`LocationTag\`."""
+enum LocationTagsOrderBy {
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  ENTITY_KIND_ASC
+  ENTITY_KIND_DESC
+  ENTITY_ID_ASC
+  ENTITY_ID_DESC
+  TAG_ASC
+  TAG_DESC
+}
+
 type Photo implements Node {
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
   id: UUID!
+
+  """Reads and enables pagination through a set of \`PhotoTag\`."""
+  photoTagsByEntityId(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PhotoTagCondition
+
+    """The method to use when ordering \`PhotoTag\`."""
+    orderBy: [PhotoTagsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PhotoTagsConnection!
+}
+
+"""A connection to a list of \`PhotoTag\` values."""
+type PhotoTagsConnection {
+  """A list of \`PhotoTag\` objects."""
+  nodes: [PhotoTag]!
+
+  """
+  A list of edges which contains the \`PhotoTag\` and cursor to aid in pagination.
+  """
+  edges: [PhotoTagsEdge]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`PhotoTag\` you could get from the connection."""
+  totalCount: Int!
+}
+
+type PhotoTag implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  entityKind: EntityKinds!
+  entityId: UUID!
+  tag: String!
+
+  """Reads a single \`Photo\` that is related to this \`PhotoTag\`."""
+  photoByEntityId: Photo
+}
+
+"""A \`PhotoTag\` edge in the connection."""
+type PhotoTagsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`PhotoTag\` at the end of the edge."""
+  node: PhotoTag
+}
+
+"""
+A condition to be used against \`PhotoTag\` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input PhotoTagCondition {
+  """Checks for equality with the object’s \`entityKind\` field."""
+  entityKind: EntityKinds
+
+  """Checks for equality with the object’s \`entityId\` field."""
+  entityId: UUID
+
+  """Checks for equality with the object’s \`tag\` field."""
+  tag: String
+}
+
+"""Methods to use when ordering \`PhotoTag\`."""
+enum PhotoTagsOrderBy {
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  ENTITY_KIND_ASC
+  ENTITY_KIND_DESC
+  ENTITY_ID_ASC
+  ENTITY_ID_DESC
+  TAG_ASC
+  TAG_DESC
 }
 
 type Profile implements Node {
@@ -2411,6 +2788,102 @@ type Profile implements Node {
   """
   nodeId: ID!
   id: UUID!
+
+  """Reads and enables pagination through a set of \`ProfileTag\`."""
+  profileTagsByEntityId(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProfileTagCondition
+
+    """The method to use when ordering \`ProfileTag\`."""
+    orderBy: [ProfileTagsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProfileTagsConnection!
+}
+
+"""A connection to a list of \`ProfileTag\` values."""
+type ProfileTagsConnection {
+  """A list of \`ProfileTag\` objects."""
+  nodes: [ProfileTag]!
+
+  """
+  A list of edges which contains the \`ProfileTag\` and cursor to aid in pagination.
+  """
+  edges: [ProfileTagsEdge]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`ProfileTag\` you could get from the connection."""
+  totalCount: Int!
+}
+
+type ProfileTag implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  entityKind: EntityKinds!
+  entityId: UUID!
+  tag: String!
+
+  """Reads a single \`Profile\` that is related to this \`ProfileTag\`."""
+  profileByEntityId: Profile
+}
+
+"""A \`ProfileTag\` edge in the connection."""
+type ProfileTagsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`ProfileTag\` at the end of the edge."""
+  node: ProfileTag
+}
+
+"""
+A condition to be used against \`ProfileTag\` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input ProfileTagCondition {
+  """Checks for equality with the object’s \`entityKind\` field."""
+  entityKind: EntityKinds
+
+  """Checks for equality with the object’s \`entityId\` field."""
+  entityId: UUID
+
+  """Checks for equality with the object’s \`tag\` field."""
+  tag: String
+}
+
+"""Methods to use when ordering \`ProfileTag\`."""
+enum ProfileTagsOrderBy {
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  ENTITY_KIND_ASC
+  ENTITY_KIND_DESC
+  ENTITY_ID_ASC
+  ENTITY_ID_DESC
+  TAG_ASC
+  TAG_DESC
 }
 
 type User implements Node {
@@ -2500,24 +2973,6 @@ type MeasurementsEdge {
   node: Measurement
 }
 
-"""A location in a connection that can be used for resuming pagination."""
-scalar Cursor
-
-"""Information about pagination in a connection."""
-type PageInfo {
-  """When paginating forwards, are there more items?"""
-  hasNextPage: Boolean!
-
-  """When paginating backwards, are there more items?"""
-  hasPreviousPage: Boolean!
-
-  """When paginating backwards, the cursor to continue."""
-  startCursor: Cursor
-
-  """When paginating forwards, the cursor to continue."""
-  endCursor: Cursor
-}
-
 """
 A condition to be used against \`Measurement\` object types. All fields are tested
 for equality and combined with a logical ‘and.’
@@ -2549,22 +3004,6 @@ enum MeasurementsOrderBy {
   VALUE_DESC
   USER_ID_ASC
   USER_ID_DESC
-}
-
-type Tag implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
-  entityKind: EntityKinds!
-  entityId: UUID!
-  tag: String!
-}
-
-enum EntityKinds {
-  PHOTOS
-  LOCATIONS
-  PROFILES
 }
 
 """A connection to a list of \`Location\` values."""
@@ -2745,59 +3184,6 @@ enum UsersOrderBy {
   NAME_DESC
 }
 
-"""A connection to a list of \`Tag\` values."""
-type TagsConnection {
-  """A list of \`Tag\` objects."""
-  nodes: [Tag]!
-
-  """
-  A list of edges which contains the \`Tag\` and cursor to aid in pagination.
-  """
-  edges: [TagsEdge]!
-
-  """Information to aid in pagination."""
-  pageInfo: PageInfo!
-
-  """The count of *all* \`Tag\` you could get from the connection."""
-  totalCount: Int!
-}
-
-"""A \`Tag\` edge in the connection."""
-type TagsEdge {
-  """A cursor for use in pagination."""
-  cursor: Cursor
-
-  """The \`Tag\` at the end of the edge."""
-  node: Tag
-}
-
-"""
-A condition to be used against \`Tag\` object types. All fields are tested for equality and combined with a logical ‘and.’
-"""
-input TagCondition {
-  """Checks for equality with the object’s \`entityKind\` field."""
-  entityKind: EntityKinds
-
-  """Checks for equality with the object’s \`entityId\` field."""
-  entityId: UUID
-
-  """Checks for equality with the object’s \`tag\` field."""
-  tag: String
-}
-
-"""Methods to use when ordering \`Tag\`."""
-enum TagsOrderBy {
-  NATURAL
-  PRIMARY_KEY_ASC
-  PRIMARY_KEY_DESC
-  ENTITY_KIND_ASC
-  ENTITY_KIND_DESC
-  ENTITY_ID_ASC
-  ENTITY_ID_DESC
-  TAG_ASC
-  TAG_DESC
-}
-
 """
 The root mutation type which contains root level fields which mutate data.
 """
@@ -2842,13 +3228,29 @@ type Mutation {
     input: CreateMeasurementInput!
   ): CreateMeasurementPayload
 
-  """Creates a single \`Tag\`."""
-  createTag(
+  """Creates a single \`LocationTag\`."""
+  createLocationTag(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: CreateTagInput!
-  ): CreateTagPayload
+    input: CreateLocationTagInput!
+  ): CreateLocationTagPayload
+
+  """Creates a single \`PhotoTag\`."""
+  createPhotoTag(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreatePhotoTagInput!
+  ): CreatePhotoTagPayload
+
+  """Creates a single \`ProfileTag\`."""
+  createProfileTag(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateProfileTagInput!
+  ): CreateProfileTagPayload
 
   """Updates a single \`Location\` using its globally unique id and a patch."""
   updateLocation(
@@ -2932,21 +3334,57 @@ type Mutation {
     input: UpdateMeasurementByTimestampAndKeyInput!
   ): UpdateMeasurementPayload
 
-  """Updates a single \`Tag\` using its globally unique id and a patch."""
-  updateTag(
+  """
+  Updates a single \`LocationTag\` using its globally unique id and a patch.
+  """
+  updateLocationTag(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: UpdateTagInput!
-  ): UpdateTagPayload
+    input: UpdateLocationTagInput!
+  ): UpdateLocationTagPayload
 
-  """Updates a single \`Tag\` using a unique key and a patch."""
-  updateTagByEntityKindAndEntityIdAndTag(
+  """Updates a single \`LocationTag\` using a unique key and a patch."""
+  updateLocationTagByEntityKindAndEntityIdAndTag(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: UpdateTagByEntityKindAndEntityIdAndTagInput!
-  ): UpdateTagPayload
+    input: UpdateLocationTagByEntityKindAndEntityIdAndTagInput!
+  ): UpdateLocationTagPayload
+
+  """Updates a single \`PhotoTag\` using its globally unique id and a patch."""
+  updatePhotoTag(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdatePhotoTagInput!
+  ): UpdatePhotoTagPayload
+
+  """Updates a single \`PhotoTag\` using a unique key and a patch."""
+  updatePhotoTagByEntityKindAndEntityIdAndTag(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdatePhotoTagByEntityKindAndEntityIdAndTagInput!
+  ): UpdatePhotoTagPayload
+
+  """
+  Updates a single \`ProfileTag\` using its globally unique id and a patch.
+  """
+  updateProfileTag(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateProfileTagInput!
+  ): UpdateProfileTagPayload
+
+  """Updates a single \`ProfileTag\` using a unique key and a patch."""
+  updateProfileTagByEntityKindAndEntityIdAndTag(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateProfileTagByEntityKindAndEntityIdAndTagInput!
+  ): UpdateProfileTagPayload
 
   """Deletes a single \`Location\` using its globally unique id."""
   deleteLocation(
@@ -3028,21 +3466,53 @@ type Mutation {
     input: DeleteMeasurementByTimestampAndKeyInput!
   ): DeleteMeasurementPayload
 
-  """Deletes a single \`Tag\` using its globally unique id."""
-  deleteTag(
+  """Deletes a single \`LocationTag\` using its globally unique id."""
+  deleteLocationTag(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: DeleteTagInput!
-  ): DeleteTagPayload
+    input: DeleteLocationTagInput!
+  ): DeleteLocationTagPayload
 
-  """Deletes a single \`Tag\` using a unique key."""
-  deleteTagByEntityKindAndEntityIdAndTag(
+  """Deletes a single \`LocationTag\` using a unique key."""
+  deleteLocationTagByEntityKindAndEntityIdAndTag(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: DeleteTagByEntityKindAndEntityIdAndTagInput!
-  ): DeleteTagPayload
+    input: DeleteLocationTagByEntityKindAndEntityIdAndTagInput!
+  ): DeleteLocationTagPayload
+
+  """Deletes a single \`PhotoTag\` using its globally unique id."""
+  deletePhotoTag(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeletePhotoTagInput!
+  ): DeletePhotoTagPayload
+
+  """Deletes a single \`PhotoTag\` using a unique key."""
+  deletePhotoTagByEntityKindAndEntityIdAndTag(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeletePhotoTagByEntityKindAndEntityIdAndTagInput!
+  ): DeletePhotoTagPayload
+
+  """Deletes a single \`ProfileTag\` using its globally unique id."""
+  deleteProfileTag(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteProfileTagInput!
+  ): DeleteProfileTagPayload
+
+  """Deletes a single \`ProfileTag\` using a unique key."""
+  deleteProfileTagByEntityKindAndEntityIdAndTag(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteProfileTagByEntityKindAndEntityIdAndTagInput!
+  ): DeleteProfileTagPayload
 }
 
 """The output of our create \`Location\` mutation."""
@@ -3252,43 +3722,136 @@ input MeasurementInput {
   userId: Int!
 }
 
-"""The output of our create \`Tag\` mutation."""
-type CreateTagPayload {
+"""The output of our create \`LocationTag\` mutation."""
+type CreateLocationTagPayload {
   """
   The exact same \`clientMutationId\` that was provided in the mutation input,
   unchanged and unused. May be used by a client to track mutations.
   """
   clientMutationId: String
 
-  """The \`Tag\` that was created by this mutation."""
-  tag: Tag
+  """The \`LocationTag\` that was created by this mutation."""
+  locationTag: LocationTag
 
   """
   Our root query field type. Allows us to run any query from our mutation payload.
   """
   query: Query
 
-  """An edge for our \`Tag\`. May be used by Relay 1."""
-  tagEdge(
-    """The method to use when ordering \`Tag\`."""
-    orderBy: [TagsOrderBy!]! = [PRIMARY_KEY_ASC]
-  ): TagsEdge
+  """An edge for our \`LocationTag\`. May be used by Relay 1."""
+  locationTagEdge(
+    """The method to use when ordering \`LocationTag\`."""
+    orderBy: [LocationTagsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): LocationTagsEdge
+
+  """Reads a single \`Location\` that is related to this \`LocationTag\`."""
+  locationByEntityId: Location
 }
 
-"""All input for the create \`Tag\` mutation."""
-input CreateTagInput {
+"""All input for the create \`LocationTag\` mutation."""
+input CreateLocationTagInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
   """
   clientMutationId: String
 
-  """The \`Tag\` to be created by this mutation."""
-  tag: TagInput!
+  """The \`LocationTag\` to be created by this mutation."""
+  locationTag: LocationTagInput!
 }
 
-"""An input for mutations affecting \`Tag\`"""
-input TagInput {
+"""An input for mutations affecting \`LocationTag\`"""
+input LocationTagInput {
+  entityKind: EntityKinds!
+  entityId: UUID!
+  tag: String!
+}
+
+"""The output of our create \`PhotoTag\` mutation."""
+type CreatePhotoTagPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`PhotoTag\` that was created by this mutation."""
+  photoTag: PhotoTag
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our \`PhotoTag\`. May be used by Relay 1."""
+  photoTagEdge(
+    """The method to use when ordering \`PhotoTag\`."""
+    orderBy: [PhotoTagsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): PhotoTagsEdge
+
+  """Reads a single \`Photo\` that is related to this \`PhotoTag\`."""
+  photoByEntityId: Photo
+}
+
+"""All input for the create \`PhotoTag\` mutation."""
+input CreatePhotoTagInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The \`PhotoTag\` to be created by this mutation."""
+  photoTag: PhotoTagInput!
+}
+
+"""An input for mutations affecting \`PhotoTag\`"""
+input PhotoTagInput {
+  entityKind: EntityKinds!
+  entityId: UUID!
+  tag: String!
+}
+
+"""The output of our create \`ProfileTag\` mutation."""
+type CreateProfileTagPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`ProfileTag\` that was created by this mutation."""
+  profileTag: ProfileTag
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our \`ProfileTag\`. May be used by Relay 1."""
+  profileTagEdge(
+    """The method to use when ordering \`ProfileTag\`."""
+    orderBy: [ProfileTagsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): ProfileTagsEdge
+
+  """Reads a single \`Profile\` that is related to this \`ProfileTag\`."""
+  profileByEntityId: Profile
+}
+
+"""All input for the create \`ProfileTag\` mutation."""
+input CreateProfileTagInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The \`ProfileTag\` to be created by this mutation."""
+  profileTag: ProfileTagInput!
+}
+
+"""An input for mutations affecting \`ProfileTag\`"""
+input ProfileTagInput {
   entityKind: EntityKinds!
   entityId: UUID!
   tag: String!
@@ -3620,31 +4183,34 @@ input UpdateMeasurementByTimestampAndKeyInput {
   measurementPatch: MeasurementPatch!
 }
 
-"""The output of our update \`Tag\` mutation."""
-type UpdateTagPayload {
+"""The output of our update \`LocationTag\` mutation."""
+type UpdateLocationTagPayload {
   """
   The exact same \`clientMutationId\` that was provided in the mutation input,
   unchanged and unused. May be used by a client to track mutations.
   """
   clientMutationId: String
 
-  """The \`Tag\` that was updated by this mutation."""
-  tag: Tag
+  """The \`LocationTag\` that was updated by this mutation."""
+  locationTag: LocationTag
 
   """
   Our root query field type. Allows us to run any query from our mutation payload.
   """
   query: Query
 
-  """An edge for our \`Tag\`. May be used by Relay 1."""
-  tagEdge(
-    """The method to use when ordering \`Tag\`."""
-    orderBy: [TagsOrderBy!]! = [PRIMARY_KEY_ASC]
-  ): TagsEdge
+  """An edge for our \`LocationTag\`. May be used by Relay 1."""
+  locationTagEdge(
+    """The method to use when ordering \`LocationTag\`."""
+    orderBy: [LocationTagsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): LocationTagsEdge
+
+  """Reads a single \`Location\` that is related to this \`LocationTag\`."""
+  locationByEntityId: Location
 }
 
-"""All input for the \`updateTag\` mutation."""
-input UpdateTagInput {
+"""All input for the \`updateLocationTag\` mutation."""
+input UpdateLocationTagInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -3652,25 +4218,29 @@ input UpdateTagInput {
   clientMutationId: String
 
   """
-  The globally unique \`ID\` which will identify a single \`Tag\` to be updated.
+  The globally unique \`ID\` which will identify a single \`LocationTag\` to be updated.
   """
   nodeId: ID!
 
   """
-  An object where the defined keys will be set on the \`Tag\` being updated.
+  An object where the defined keys will be set on the \`LocationTag\` being updated.
   """
-  tagPatch: TagPatch!
+  locationTagPatch: LocationTagPatch!
 }
 
-"""Represents an update to a \`Tag\`. Fields that are set will be updated."""
-input TagPatch {
+"""
+Represents an update to a \`LocationTag\`. Fields that are set will be updated.
+"""
+input LocationTagPatch {
   entityKind: EntityKinds
   entityId: UUID
   tag: String
 }
 
-"""All input for the \`updateTagByEntityKindAndEntityIdAndTag\` mutation."""
-input UpdateTagByEntityKindAndEntityIdAndTagInput {
+"""
+All input for the \`updateLocationTagByEntityKindAndEntityIdAndTag\` mutation.
+"""
+input UpdateLocationTagByEntityKindAndEntityIdAndTagInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -3681,9 +4251,155 @@ input UpdateTagByEntityKindAndEntityIdAndTagInput {
   tag: String!
 
   """
-  An object where the defined keys will be set on the \`Tag\` being updated.
+  An object where the defined keys will be set on the \`LocationTag\` being updated.
   """
-  tagPatch: TagPatch!
+  locationTagPatch: LocationTagPatch!
+}
+
+"""The output of our update \`PhotoTag\` mutation."""
+type UpdatePhotoTagPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`PhotoTag\` that was updated by this mutation."""
+  photoTag: PhotoTag
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our \`PhotoTag\`. May be used by Relay 1."""
+  photoTagEdge(
+    """The method to use when ordering \`PhotoTag\`."""
+    orderBy: [PhotoTagsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): PhotoTagsEdge
+
+  """Reads a single \`Photo\` that is related to this \`PhotoTag\`."""
+  photoByEntityId: Photo
+}
+
+"""All input for the \`updatePhotoTag\` mutation."""
+input UpdatePhotoTagInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`PhotoTag\` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the \`PhotoTag\` being updated.
+  """
+  photoTagPatch: PhotoTagPatch!
+}
+
+"""
+Represents an update to a \`PhotoTag\`. Fields that are set will be updated.
+"""
+input PhotoTagPatch {
+  entityKind: EntityKinds
+  entityId: UUID
+  tag: String
+}
+
+"""
+All input for the \`updatePhotoTagByEntityKindAndEntityIdAndTag\` mutation.
+"""
+input UpdatePhotoTagByEntityKindAndEntityIdAndTagInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  entityKind: EntityKinds!
+  entityId: UUID!
+  tag: String!
+
+  """
+  An object where the defined keys will be set on the \`PhotoTag\` being updated.
+  """
+  photoTagPatch: PhotoTagPatch!
+}
+
+"""The output of our update \`ProfileTag\` mutation."""
+type UpdateProfileTagPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`ProfileTag\` that was updated by this mutation."""
+  profileTag: ProfileTag
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our \`ProfileTag\`. May be used by Relay 1."""
+  profileTagEdge(
+    """The method to use when ordering \`ProfileTag\`."""
+    orderBy: [ProfileTagsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): ProfileTagsEdge
+
+  """Reads a single \`Profile\` that is related to this \`ProfileTag\`."""
+  profileByEntityId: Profile
+}
+
+"""All input for the \`updateProfileTag\` mutation."""
+input UpdateProfileTagInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`ProfileTag\` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the \`ProfileTag\` being updated.
+  """
+  profileTagPatch: ProfileTagPatch!
+}
+
+"""
+Represents an update to a \`ProfileTag\`. Fields that are set will be updated.
+"""
+input ProfileTagPatch {
+  entityKind: EntityKinds
+  entityId: UUID
+  tag: String
+}
+
+"""
+All input for the \`updateProfileTagByEntityKindAndEntityIdAndTag\` mutation.
+"""
+input UpdateProfileTagByEntityKindAndEntityIdAndTagInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  entityKind: EntityKinds!
+  entityId: UUID!
+  tag: String!
+
+  """
+  An object where the defined keys will be set on the \`ProfileTag\` being updated.
+  """
+  profileTagPatch: ProfileTagPatch!
 }
 
 """The output of our delete \`Location\` mutation."""
@@ -3930,32 +4646,35 @@ input DeleteMeasurementByTimestampAndKeyInput {
   key: String!
 }
 
-"""The output of our delete \`Tag\` mutation."""
-type DeleteTagPayload {
+"""The output of our delete \`LocationTag\` mutation."""
+type DeleteLocationTagPayload {
   """
   The exact same \`clientMutationId\` that was provided in the mutation input,
   unchanged and unused. May be used by a client to track mutations.
   """
   clientMutationId: String
 
-  """The \`Tag\` that was deleted by this mutation."""
-  tag: Tag
-  deletedTagId: ID
+  """The \`LocationTag\` that was deleted by this mutation."""
+  locationTag: LocationTag
+  deletedLocationTagId: ID
 
   """
   Our root query field type. Allows us to run any query from our mutation payload.
   """
   query: Query
 
-  """An edge for our \`Tag\`. May be used by Relay 1."""
-  tagEdge(
-    """The method to use when ordering \`Tag\`."""
-    orderBy: [TagsOrderBy!]! = [PRIMARY_KEY_ASC]
-  ): TagsEdge
+  """An edge for our \`LocationTag\`. May be used by Relay 1."""
+  locationTagEdge(
+    """The method to use when ordering \`LocationTag\`."""
+    orderBy: [LocationTagsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): LocationTagsEdge
+
+  """Reads a single \`Location\` that is related to this \`LocationTag\`."""
+  locationByEntityId: Location
 }
 
-"""All input for the \`deleteTag\` mutation."""
-input DeleteTagInput {
+"""All input for the \`deleteLocationTag\` mutation."""
+input DeleteLocationTagInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -3963,13 +4682,125 @@ input DeleteTagInput {
   clientMutationId: String
 
   """
-  The globally unique \`ID\` which will identify a single \`Tag\` to be deleted.
+  The globally unique \`ID\` which will identify a single \`LocationTag\` to be deleted.
   """
   nodeId: ID!
 }
 
-"""All input for the \`deleteTagByEntityKindAndEntityIdAndTag\` mutation."""
-input DeleteTagByEntityKindAndEntityIdAndTagInput {
+"""
+All input for the \`deleteLocationTagByEntityKindAndEntityIdAndTag\` mutation.
+"""
+input DeleteLocationTagByEntityKindAndEntityIdAndTagInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  entityKind: EntityKinds!
+  entityId: UUID!
+  tag: String!
+}
+
+"""The output of our delete \`PhotoTag\` mutation."""
+type DeletePhotoTagPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`PhotoTag\` that was deleted by this mutation."""
+  photoTag: PhotoTag
+  deletedPhotoTagId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our \`PhotoTag\`. May be used by Relay 1."""
+  photoTagEdge(
+    """The method to use when ordering \`PhotoTag\`."""
+    orderBy: [PhotoTagsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): PhotoTagsEdge
+
+  """Reads a single \`Photo\` that is related to this \`PhotoTag\`."""
+  photoByEntityId: Photo
+}
+
+"""All input for the \`deletePhotoTag\` mutation."""
+input DeletePhotoTagInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`PhotoTag\` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""
+All input for the \`deletePhotoTagByEntityKindAndEntityIdAndTag\` mutation.
+"""
+input DeletePhotoTagByEntityKindAndEntityIdAndTagInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  entityKind: EntityKinds!
+  entityId: UUID!
+  tag: String!
+}
+
+"""The output of our delete \`ProfileTag\` mutation."""
+type DeleteProfileTagPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`ProfileTag\` that was deleted by this mutation."""
+  profileTag: ProfileTag
+  deletedProfileTagId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our \`ProfileTag\`. May be used by Relay 1."""
+  profileTagEdge(
+    """The method to use when ordering \`ProfileTag\`."""
+    orderBy: [ProfileTagsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): ProfileTagsEdge
+
+  """Reads a single \`Profile\` that is related to this \`ProfileTag\`."""
+  profileByEntityId: Profile
+}
+
+"""All input for the \`deleteProfileTag\` mutation."""
+input DeleteProfileTagInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`ProfileTag\` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""
+All input for the \`deleteProfileTagByEntityKindAndEntityIdAndTag\` mutation.
+"""
+input DeleteProfileTagByEntityKindAndEntityIdAndTagInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -3988,6 +4819,36 @@ export const objects = {
       allLocations: {
         plan() {
           return connection(resource_locationsPgResource.find());
+        },
+        args: {
+          first(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          },
+          last(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          },
+          offset(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          },
+          before(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          },
+          after(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          },
+          condition(_condition, $connection, arg) {
+            const $select = $connection.getSubplan();
+            arg.apply($select, qbWhereBuilder);
+          },
+          orderBy(parent, $connection, value) {
+            const $select = $connection.getSubplan();
+            value.apply($select);
+          }
+        }
+      },
+      allLocationTags: {
+        plan() {
+          return connection(resource_location_tagsPgResource.find());
         },
         args: {
           first(_, $connection, arg) {
@@ -4075,6 +4936,36 @@ export const objects = {
           }
         }
       },
+      allPhotoTags: {
+        plan() {
+          return connection(resource_photo_tagsPgResource.find());
+        },
+        args: {
+          first(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          },
+          last(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          },
+          offset(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          },
+          before(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          },
+          after(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          },
+          condition(_condition, $connection, arg) {
+            const $select = $connection.getSubplan();
+            arg.apply($select, qbWhereBuilder);
+          },
+          orderBy(parent, $connection, value) {
+            const $select = $connection.getSubplan();
+            value.apply($select);
+          }
+        }
+      },
       allProfiles: {
         plan() {
           return connection(resource_profilesPgResource.find());
@@ -4105,9 +4996,9 @@ export const objects = {
           }
         }
       },
-      allTags: {
+      allProfileTags: {
         plan() {
-          return connection(resource_tagsPgResource.find());
+          return connection(resource_profile_tagsPgResource.find());
         },
         args: {
           first(_, $connection, arg) {
@@ -4176,6 +5067,21 @@ export const objects = {
           id: $id
         });
       },
+      locationTag(_$parent, args) {
+        const $nodeId = args.getRaw("nodeId");
+        return nodeFetcher_LocationTag($nodeId);
+      },
+      locationTagByEntityKindAndEntityIdAndTag(_$root, {
+        $entityKind,
+        $entityId,
+        $tag
+      }) {
+        return resource_location_tagsPgResource.get({
+          entity_kind: $entityKind,
+          entity_id: $entityId,
+          tag: $tag
+        });
+      },
       measurement(_$parent, args) {
         const $nodeId = args.getRaw("nodeId");
         return nodeFetcher_Measurement($nodeId);
@@ -4207,6 +5113,21 @@ export const objects = {
           id: $id
         });
       },
+      photoTag(_$parent, args) {
+        const $nodeId = args.getRaw("nodeId");
+        return nodeFetcher_PhotoTag($nodeId);
+      },
+      photoTagByEntityKindAndEntityIdAndTag(_$root, {
+        $entityKind,
+        $entityId,
+        $tag
+      }) {
+        return resource_photo_tagsPgResource.get({
+          entity_kind: $entityKind,
+          entity_id: $entityId,
+          tag: $tag
+        });
+      },
       profile(_$parent, args) {
         const $nodeId = args.getRaw("nodeId");
         return nodeFetcher_Profile($nodeId);
@@ -4218,23 +5139,23 @@ export const objects = {
           id: $id
         });
       },
-      query() {
-        return rootValue();
-      },
-      tag(_$parent, args) {
+      profileTag(_$parent, args) {
         const $nodeId = args.getRaw("nodeId");
-        return nodeFetcher_Tag($nodeId);
+        return nodeFetcher_ProfileTag($nodeId);
       },
-      tagByEntityKindAndEntityIdAndTag(_$root, {
+      profileTagByEntityKindAndEntityIdAndTag(_$root, {
         $entityKind,
         $entityId,
         $tag
       }) {
-        return resource_tagsPgResource.get({
+        return resource_profile_tagsPgResource.get({
           entity_kind: $entityKind,
           entity_id: $entityId,
           tag: $tag
         });
+      },
+      query() {
+        return rootValue();
       },
       user(_$parent, args) {
         const $nodeId = args.getRaw("nodeId");
@@ -4255,6 +5176,21 @@ export const objects = {
       createLocation: {
         plan(_, args) {
           const $insert = pgInsertSingle(resource_locationsPgResource, Object.create(null));
+          args.apply($insert);
+          const plan = object({
+            result: $insert
+          });
+          return plan;
+        },
+        args: {
+          input(_, $object) {
+            return $object;
+          }
+        }
+      },
+      createLocationTag: {
+        plan(_, args) {
+          const $insert = pgInsertSingle(resource_location_tagsPgResource, Object.create(null));
           args.apply($insert);
           const plan = object({
             result: $insert
@@ -4297,6 +5233,21 @@ export const objects = {
           }
         }
       },
+      createPhotoTag: {
+        plan(_, args) {
+          const $insert = pgInsertSingle(resource_photo_tagsPgResource, Object.create(null));
+          args.apply($insert);
+          const plan = object({
+            result: $insert
+          });
+          return plan;
+        },
+        args: {
+          input(_, $object) {
+            return $object;
+          }
+        }
+      },
       createProfile: {
         plan(_, args) {
           const $insert = pgInsertSingle(resource_profilesPgResource, Object.create(null));
@@ -4312,9 +5263,9 @@ export const objects = {
           }
         }
       },
-      createTag: {
+      createProfileTag: {
         plan(_, args) {
-          const $insert = pgInsertSingle(resource_tagsPgResource, Object.create(null));
+          const $insert = pgInsertSingle(resource_profile_tagsPgResource, Object.create(null));
           args.apply($insert);
           const plan = object({
             result: $insert
@@ -4360,6 +5311,38 @@ export const objects = {
         plan(_$root, args) {
           const $delete = pgDeleteSingle(resource_locationsPgResource, {
             id: args.getRaw(['input', "id"])
+          });
+          args.apply($delete);
+          return object({
+            result: $delete
+          });
+        },
+        args: {
+          input(_, $object) {
+            return $object;
+          }
+        }
+      },
+      deleteLocationTag: {
+        plan(_$root, args) {
+          const $delete = pgDeleteSingle(resource_location_tagsPgResource, specFromArgs_LocationTag2(args));
+          args.apply($delete);
+          return object({
+            result: $delete
+          });
+        },
+        args: {
+          input(_, $object) {
+            return $object;
+          }
+        }
+      },
+      deleteLocationTagByEntityKindAndEntityIdAndTag: {
+        plan(_$root, args) {
+          const $delete = pgDeleteSingle(resource_location_tagsPgResource, {
+            entity_kind: args.getRaw(['input', "entityKind"]),
+            entity_id: args.getRaw(['input', "entityId"]),
+            tag: args.getRaw(['input', "tag"])
           });
           args.apply($delete);
           return object({
@@ -4433,6 +5416,38 @@ export const objects = {
           }
         }
       },
+      deletePhotoTag: {
+        plan(_$root, args) {
+          const $delete = pgDeleteSingle(resource_photo_tagsPgResource, specFromArgs_PhotoTag2(args));
+          args.apply($delete);
+          return object({
+            result: $delete
+          });
+        },
+        args: {
+          input(_, $object) {
+            return $object;
+          }
+        }
+      },
+      deletePhotoTagByEntityKindAndEntityIdAndTag: {
+        plan(_$root, args) {
+          const $delete = pgDeleteSingle(resource_photo_tagsPgResource, {
+            entity_kind: args.getRaw(['input', "entityKind"]),
+            entity_id: args.getRaw(['input', "entityId"]),
+            tag: args.getRaw(['input', "tag"])
+          });
+          args.apply($delete);
+          return object({
+            result: $delete
+          });
+        },
+        args: {
+          input(_, $object) {
+            return $object;
+          }
+        }
+      },
       deleteProfile: {
         plan(_$root, args) {
           const $delete = pgDeleteSingle(resource_profilesPgResource, specFromArgs_Profile2(args));
@@ -4463,9 +5478,9 @@ export const objects = {
           }
         }
       },
-      deleteTag: {
+      deleteProfileTag: {
         plan(_$root, args) {
-          const $delete = pgDeleteSingle(resource_tagsPgResource, specFromArgs_Tag2(args));
+          const $delete = pgDeleteSingle(resource_profile_tagsPgResource, specFromArgs_ProfileTag2(args));
           args.apply($delete);
           return object({
             result: $delete
@@ -4477,9 +5492,9 @@ export const objects = {
           }
         }
       },
-      deleteTagByEntityKindAndEntityIdAndTag: {
+      deleteProfileTagByEntityKindAndEntityIdAndTag: {
         plan(_$root, args) {
-          const $delete = pgDeleteSingle(resource_tagsPgResource, {
+          const $delete = pgDeleteSingle(resource_profile_tagsPgResource, {
             entity_kind: args.getRaw(['input', "entityKind"]),
             entity_id: args.getRaw(['input', "entityId"]),
             tag: args.getRaw(['input', "tag"])
@@ -4555,6 +5570,38 @@ export const objects = {
           }
         }
       },
+      updateLocationTag: {
+        plan(_$root, args) {
+          const $update = pgUpdateSingle(resource_location_tagsPgResource, specFromArgs_LocationTag(args));
+          args.apply($update);
+          return object({
+            result: $update
+          });
+        },
+        args: {
+          input(_, $object) {
+            return $object;
+          }
+        }
+      },
+      updateLocationTagByEntityKindAndEntityIdAndTag: {
+        plan(_$root, args) {
+          const $update = pgUpdateSingle(resource_location_tagsPgResource, {
+            entity_kind: args.getRaw(['input', "entityKind"]),
+            entity_id: args.getRaw(['input', "entityId"]),
+            tag: args.getRaw(['input', "tag"])
+          });
+          args.apply($update);
+          return object({
+            result: $update
+          });
+        },
+        args: {
+          input(_, $object) {
+            return $object;
+          }
+        }
+      },
       updateMeasurement: {
         plan(_$root, args) {
           const $update = pgUpdateSingle(resource_measurementsPgResource, specFromArgs_Measurement(args));
@@ -4616,6 +5663,38 @@ export const objects = {
           }
         }
       },
+      updatePhotoTag: {
+        plan(_$root, args) {
+          const $update = pgUpdateSingle(resource_photo_tagsPgResource, specFromArgs_PhotoTag(args));
+          args.apply($update);
+          return object({
+            result: $update
+          });
+        },
+        args: {
+          input(_, $object) {
+            return $object;
+          }
+        }
+      },
+      updatePhotoTagByEntityKindAndEntityIdAndTag: {
+        plan(_$root, args) {
+          const $update = pgUpdateSingle(resource_photo_tagsPgResource, {
+            entity_kind: args.getRaw(['input', "entityKind"]),
+            entity_id: args.getRaw(['input', "entityId"]),
+            tag: args.getRaw(['input', "tag"])
+          });
+          args.apply($update);
+          return object({
+            result: $update
+          });
+        },
+        args: {
+          input(_, $object) {
+            return $object;
+          }
+        }
+      },
       updateProfile: {
         plan(_$root, args) {
           const $update = pgUpdateSingle(resource_profilesPgResource, specFromArgs_Profile(args));
@@ -4646,9 +5725,9 @@ export const objects = {
           }
         }
       },
-      updateTag: {
+      updateProfileTag: {
         plan(_$root, args) {
-          const $update = pgUpdateSingle(resource_tagsPgResource, specFromArgs_Tag(args));
+          const $update = pgUpdateSingle(resource_profile_tagsPgResource, specFromArgs_ProfileTag(args));
           args.apply($update);
           return object({
             result: $update
@@ -4660,9 +5739,9 @@ export const objects = {
           }
         }
       },
-      updateTagByEntityKindAndEntityIdAndTag: {
+      updateProfileTagByEntityKindAndEntityIdAndTag: {
         plan(_$root, args) {
-          const $update = pgUpdateSingle(resource_tagsPgResource, {
+          const $update = pgUpdateSingle(resource_profile_tagsPgResource, {
             entity_kind: args.getRaw(['input', "entityKind"]),
             entity_id: args.getRaw(['input', "entityId"]),
             tag: args.getRaw(['input', "tag"])
@@ -4728,6 +5807,29 @@ export const objects = {
       }
     }
   },
+  CreateLocationTagPayload: {
+    assertStep: assertExecutableStep,
+    plans: {
+      clientMutationId($mutation) {
+        const $insert = $mutation.getStepForKey("result");
+        return $insert.getMeta("clientMutationId");
+      },
+      locationByEntityId($record) {
+        return resource_locationsPgResource.get({
+          id: $record.get("result").get("entity_id")
+        });
+      },
+      locationTag($object) {
+        return $object.get("result");
+      },
+      locationTagEdge($mutation, fieldArgs) {
+        return pgMutationPayloadEdge(resource_location_tagsPgResource, location_tagsUniques[0].attributes, $mutation, fieldArgs);
+      },
+      query() {
+        return rootValue();
+      }
+    }
+  },
   CreateMeasurementPayload: {
     assertStep: assertExecutableStep,
     plans: {
@@ -4769,6 +5871,29 @@ export const objects = {
       }
     }
   },
+  CreatePhotoTagPayload: {
+    assertStep: assertExecutableStep,
+    plans: {
+      clientMutationId($mutation) {
+        const $insert = $mutation.getStepForKey("result");
+        return $insert.getMeta("clientMutationId");
+      },
+      photoByEntityId($record) {
+        return resource_photosPgResource.get({
+          id: $record.get("result").get("entity_id")
+        });
+      },
+      photoTag($object) {
+        return $object.get("result");
+      },
+      photoTagEdge($mutation, fieldArgs) {
+        return pgMutationPayloadEdge(resource_photo_tagsPgResource, photo_tagsUniques[0].attributes, $mutation, fieldArgs);
+      },
+      query() {
+        return rootValue();
+      }
+    }
+  },
   CreateProfilePayload: {
     assertStep: assertExecutableStep,
     plans: {
@@ -4787,21 +5912,26 @@ export const objects = {
       }
     }
   },
-  CreateTagPayload: {
+  CreateProfileTagPayload: {
     assertStep: assertExecutableStep,
     plans: {
       clientMutationId($mutation) {
         const $insert = $mutation.getStepForKey("result");
         return $insert.getMeta("clientMutationId");
       },
-      query() {
-        return rootValue();
+      profileByEntityId($record) {
+        return resource_profilesPgResource.get({
+          id: $record.get("result").get("entity_id")
+        });
       },
-      tag($object) {
+      profileTag($object) {
         return $object.get("result");
       },
-      tagEdge($mutation, fieldArgs) {
-        return pgMutationPayloadEdge(resource_tagsPgResource, tagsUniques[0].attributes, $mutation, fieldArgs);
+      profileTagEdge($mutation, fieldArgs) {
+        return pgMutationPayloadEdge(resource_profile_tagsPgResource, profile_tagsUniques[0].attributes, $mutation, fieldArgs);
+      },
+      query() {
+        return rootValue();
       }
     }
   },
@@ -4840,6 +5970,34 @@ export const objects = {
       },
       locationEdge($mutation, fieldArgs) {
         return pgMutationPayloadEdge(resource_locationsPgResource, locationsUniques[0].attributes, $mutation, fieldArgs);
+      },
+      query() {
+        return rootValue();
+      }
+    }
+  },
+  DeleteLocationTagPayload: {
+    assertStep: ObjectStep,
+    plans: {
+      clientMutationId($mutation) {
+        const $result = $mutation.getStepForKey("result");
+        return $result.getMeta("clientMutationId");
+      },
+      deletedLocationTagId($object) {
+        const $record = $object.getStepForKey("result");
+        const specifier = nodeIdHandler_LocationTag.plan($record);
+        return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
+      },
+      locationByEntityId($record) {
+        return resource_locationsPgResource.get({
+          id: $record.get("result").get("entity_id")
+        });
+      },
+      locationTag($object) {
+        return $object.get("result");
+      },
+      locationTagEdge($mutation, fieldArgs) {
+        return pgMutationPayloadEdge(resource_location_tagsPgResource, location_tagsUniques[0].attributes, $mutation, fieldArgs);
       },
       query() {
         return rootValue();
@@ -4897,6 +6055,34 @@ export const objects = {
       }
     }
   },
+  DeletePhotoTagPayload: {
+    assertStep: ObjectStep,
+    plans: {
+      clientMutationId($mutation) {
+        const $result = $mutation.getStepForKey("result");
+        return $result.getMeta("clientMutationId");
+      },
+      deletedPhotoTagId($object) {
+        const $record = $object.getStepForKey("result");
+        const specifier = nodeIdHandler_PhotoTag.plan($record);
+        return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
+      },
+      photoByEntityId($record) {
+        return resource_photosPgResource.get({
+          id: $record.get("result").get("entity_id")
+        });
+      },
+      photoTag($object) {
+        return $object.get("result");
+      },
+      photoTagEdge($mutation, fieldArgs) {
+        return pgMutationPayloadEdge(resource_photo_tagsPgResource, photo_tagsUniques[0].attributes, $mutation, fieldArgs);
+      },
+      query() {
+        return rootValue();
+      }
+    }
+  },
   DeleteProfilePayload: {
     assertStep: ObjectStep,
     plans: {
@@ -4920,26 +6106,31 @@ export const objects = {
       }
     }
   },
-  DeleteTagPayload: {
+  DeleteProfileTagPayload: {
     assertStep: ObjectStep,
     plans: {
       clientMutationId($mutation) {
         const $result = $mutation.getStepForKey("result");
         return $result.getMeta("clientMutationId");
       },
-      deletedTagId($object) {
+      deletedProfileTagId($object) {
         const $record = $object.getStepForKey("result");
-        const specifier = nodeIdHandler_Tag.plan($record);
+        const specifier = nodeIdHandler_ProfileTag.plan($record);
         return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
+      },
+      profileByEntityId($record) {
+        return resource_profilesPgResource.get({
+          id: $record.get("result").get("entity_id")
+        });
+      },
+      profileTag($object) {
+        return $object.get("result");
+      },
+      profileTagEdge($mutation, fieldArgs) {
+        return pgMutationPayloadEdge(resource_profile_tagsPgResource, profile_tagsUniques[0].attributes, $mutation, fieldArgs);
       },
       query() {
         return rootValue();
-      },
-      tag($object) {
-        return $object.get("result");
-      },
-      tagEdge($mutation, fieldArgs) {
-        return pgMutationPayloadEdge(resource_tagsPgResource, tagsUniques[0].attributes, $mutation, fieldArgs);
       }
     }
   },
@@ -4969,6 +6160,39 @@ export const objects = {
   Location: {
     assertStep: assertPgClassSingleStep,
     plans: {
+      locationTagsByEntityId: {
+        plan($record) {
+          const $records = resource_location_tagsPgResource.find({
+            entity_id: $record.get("id")
+          });
+          return connection($records);
+        },
+        args: {
+          first(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          },
+          last(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          },
+          offset(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          },
+          before(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          },
+          after(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          },
+          condition(_condition, $connection, arg) {
+            const $select = $connection.getSubplan();
+            arg.apply($select, qbWhereBuilder);
+          },
+          orderBy(parent, $connection, value) {
+            const $select = $connection.getSubplan();
+            value.apply($select);
+          }
+        }
+      },
       nodeId($parent) {
         const specifier = nodeIdHandler_Location.plan($parent);
         return lambda(specifier, nodeIdCodecs[nodeIdHandler_Location.codec.name].encode);
@@ -4983,6 +6207,41 @@ export const objects = {
     }
   },
   LocationsConnection: {
+    assertStep: ConnectionStep,
+    plans: {
+      totalCount($connection) {
+        return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint, false);
+      }
+    }
+  },
+  LocationTag: {
+    assertStep: assertPgClassSingleStep,
+    plans: {
+      entityId($record) {
+        return $record.get("entity_id");
+      },
+      entityKind($record) {
+        return $record.get("entity_kind");
+      },
+      locationByEntityId($record) {
+        return resource_locationsPgResource.get({
+          id: $record.get("entity_id")
+        });
+      },
+      nodeId($parent) {
+        const specifier = nodeIdHandler_LocationTag.plan($parent);
+        return lambda(specifier, nodeIdCodecs[nodeIdHandler_LocationTag.codec.name].encode);
+      }
+    },
+    planType($specifier) {
+      const spec = Object.create(null);
+      for (const pkCol of location_tagsUniques[0].attributes) {
+        spec[pkCol] = get2($specifier, pkCol);
+      }
+      return resource_location_tagsPgResource.get(spec);
+    }
+  },
+  LocationTagsConnection: {
     assertStep: ConnectionStep,
     plans: {
       totalCount($connection) {
@@ -5028,6 +6287,39 @@ export const objects = {
       nodeId($parent) {
         const specifier = nodeIdHandler_Photo.plan($parent);
         return lambda(specifier, nodeIdCodecs[nodeIdHandler_Photo.codec.name].encode);
+      },
+      photoTagsByEntityId: {
+        plan($record) {
+          const $records = resource_photo_tagsPgResource.find({
+            entity_id: $record.get("id")
+          });
+          return connection($records);
+        },
+        args: {
+          first(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          },
+          last(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          },
+          offset(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          },
+          before(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          },
+          after(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          },
+          condition(_condition, $connection, arg) {
+            const $select = $connection.getSubplan();
+            arg.apply($select, qbWhereBuilder);
+          },
+          orderBy(parent, $connection, value) {
+            const $select = $connection.getSubplan();
+            value.apply($select);
+          }
+        }
       }
     },
     planType($specifier) {
@@ -5046,12 +6338,80 @@ export const objects = {
       }
     }
   },
+  PhotoTag: {
+    assertStep: assertPgClassSingleStep,
+    plans: {
+      entityId($record) {
+        return $record.get("entity_id");
+      },
+      entityKind($record) {
+        return $record.get("entity_kind");
+      },
+      nodeId($parent) {
+        const specifier = nodeIdHandler_PhotoTag.plan($parent);
+        return lambda(specifier, nodeIdCodecs[nodeIdHandler_PhotoTag.codec.name].encode);
+      },
+      photoByEntityId($record) {
+        return resource_photosPgResource.get({
+          id: $record.get("entity_id")
+        });
+      }
+    },
+    planType($specifier) {
+      const spec = Object.create(null);
+      for (const pkCol of photo_tagsUniques[0].attributes) {
+        spec[pkCol] = get2($specifier, pkCol);
+      }
+      return resource_photo_tagsPgResource.get(spec);
+    }
+  },
+  PhotoTagsConnection: {
+    assertStep: ConnectionStep,
+    plans: {
+      totalCount($connection) {
+        return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint, false);
+      }
+    }
+  },
   Profile: {
     assertStep: assertPgClassSingleStep,
     plans: {
       nodeId($parent) {
         const specifier = nodeIdHandler_Profile.plan($parent);
         return lambda(specifier, nodeIdCodecs[nodeIdHandler_Profile.codec.name].encode);
+      },
+      profileTagsByEntityId: {
+        plan($record) {
+          const $records = resource_profile_tagsPgResource.find({
+            entity_id: $record.get("id")
+          });
+          return connection($records);
+        },
+        args: {
+          first(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          },
+          last(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          },
+          offset(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          },
+          before(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          },
+          after(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          },
+          condition(_condition, $connection, arg) {
+            const $select = $connection.getSubplan();
+            arg.apply($select, qbWhereBuilder);
+          },
+          orderBy(parent, $connection, value) {
+            const $select = $connection.getSubplan();
+            value.apply($select);
+          }
+        }
       }
     },
     planType($specifier) {
@@ -5070,7 +6430,7 @@ export const objects = {
       }
     }
   },
-  Tag: {
+  ProfileTag: {
     assertStep: assertPgClassSingleStep,
     plans: {
       entityId($record) {
@@ -5080,19 +6440,24 @@ export const objects = {
         return $record.get("entity_kind");
       },
       nodeId($parent) {
-        const specifier = nodeIdHandler_Tag.plan($parent);
-        return lambda(specifier, nodeIdCodecs[nodeIdHandler_Tag.codec.name].encode);
+        const specifier = nodeIdHandler_ProfileTag.plan($parent);
+        return lambda(specifier, nodeIdCodecs[nodeIdHandler_ProfileTag.codec.name].encode);
+      },
+      profileByEntityId($record) {
+        return resource_profilesPgResource.get({
+          id: $record.get("entity_id")
+        });
       }
     },
     planType($specifier) {
       const spec = Object.create(null);
-      for (const pkCol of tagsUniques[0].attributes) {
+      for (const pkCol of profile_tagsUniques[0].attributes) {
         spec[pkCol] = get2($specifier, pkCol);
       }
-      return resource_tagsPgResource.get(spec);
+      return resource_profile_tagsPgResource.get(spec);
     }
   },
-  TagsConnection: {
+  ProfileTagsConnection: {
     assertStep: ConnectionStep,
     plans: {
       totalCount($connection) {
@@ -5112,6 +6477,29 @@ export const objects = {
       },
       locationEdge($mutation, fieldArgs) {
         return pgMutationPayloadEdge(resource_locationsPgResource, locationsUniques[0].attributes, $mutation, fieldArgs);
+      },
+      query() {
+        return rootValue();
+      }
+    }
+  },
+  UpdateLocationTagPayload: {
+    assertStep: ObjectStep,
+    plans: {
+      clientMutationId($mutation) {
+        const $result = $mutation.getStepForKey("result");
+        return $result.getMeta("clientMutationId");
+      },
+      locationByEntityId($record) {
+        return resource_locationsPgResource.get({
+          id: $record.get("result").get("entity_id")
+        });
+      },
+      locationTag($object) {
+        return $object.get("result");
+      },
+      locationTagEdge($mutation, fieldArgs) {
+        return pgMutationPayloadEdge(resource_location_tagsPgResource, location_tagsUniques[0].attributes, $mutation, fieldArgs);
       },
       query() {
         return rootValue();
@@ -5159,6 +6547,29 @@ export const objects = {
       }
     }
   },
+  UpdatePhotoTagPayload: {
+    assertStep: ObjectStep,
+    plans: {
+      clientMutationId($mutation) {
+        const $result = $mutation.getStepForKey("result");
+        return $result.getMeta("clientMutationId");
+      },
+      photoByEntityId($record) {
+        return resource_photosPgResource.get({
+          id: $record.get("result").get("entity_id")
+        });
+      },
+      photoTag($object) {
+        return $object.get("result");
+      },
+      photoTagEdge($mutation, fieldArgs) {
+        return pgMutationPayloadEdge(resource_photo_tagsPgResource, photo_tagsUniques[0].attributes, $mutation, fieldArgs);
+      },
+      query() {
+        return rootValue();
+      }
+    }
+  },
   UpdateProfilePayload: {
     assertStep: ObjectStep,
     plans: {
@@ -5177,21 +6588,26 @@ export const objects = {
       }
     }
   },
-  UpdateTagPayload: {
+  UpdateProfileTagPayload: {
     assertStep: ObjectStep,
     plans: {
       clientMutationId($mutation) {
         const $result = $mutation.getStepForKey("result");
         return $result.getMeta("clientMutationId");
       },
-      query() {
-        return rootValue();
+      profileByEntityId($record) {
+        return resource_profilesPgResource.get({
+          id: $record.get("result").get("entity_id")
+        });
       },
-      tag($object) {
+      profileTag($object) {
         return $object.get("result");
       },
-      tagEdge($mutation, fieldArgs) {
-        return pgMutationPayloadEdge(resource_tagsPgResource, tagsUniques[0].attributes, $mutation, fieldArgs);
+      profileTagEdge($mutation, fieldArgs) {
+        return pgMutationPayloadEdge(resource_profile_tagsPgResource, profile_tagsUniques[0].attributes, $mutation, fieldArgs);
+      },
+      query() {
+        return rootValue();
       }
     }
   },
@@ -5303,6 +6719,18 @@ export const inputObjects = {
       }
     }
   },
+  CreateLocationTagInput: {
+    plans: {
+      clientMutationId(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      },
+      locationTag(qb, arg) {
+        if (arg != null) {
+          return qb.setBuilder();
+        }
+      }
+    }
+  },
   CreateMeasurementInput: {
     plans: {
       clientMutationId(qb, val) {
@@ -5327,6 +6755,18 @@ export const inputObjects = {
       }
     }
   },
+  CreatePhotoTagInput: {
+    plans: {
+      clientMutationId(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      },
+      photoTag(qb, arg) {
+        if (arg != null) {
+          return qb.setBuilder();
+        }
+      }
+    }
+  },
   CreateProfileInput: {
     plans: {
       clientMutationId(qb, val) {
@@ -5339,12 +6779,12 @@ export const inputObjects = {
       }
     }
   },
-  CreateTagInput: {
+  CreateProfileTagInput: {
     plans: {
       clientMutationId(qb, val) {
         qb.setMeta("clientMutationId", val);
       },
-      tag(qb, arg) {
+      profileTag(qb, arg) {
         if (arg != null) {
           return qb.setBuilder();
         }
@@ -5371,6 +6811,20 @@ export const inputObjects = {
     }
   },
   DeleteLocationInput: {
+    plans: {
+      clientMutationId(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      }
+    }
+  },
+  DeleteLocationTagByEntityKindAndEntityIdAndTagInput: {
+    plans: {
+      clientMutationId(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      }
+    }
+  },
+  DeleteLocationTagInput: {
     plans: {
       clientMutationId(qb, val) {
         qb.setMeta("clientMutationId", val);
@@ -5405,6 +6859,20 @@ export const inputObjects = {
       }
     }
   },
+  DeletePhotoTagByEntityKindAndEntityIdAndTagInput: {
+    plans: {
+      clientMutationId(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      }
+    }
+  },
+  DeletePhotoTagInput: {
+    plans: {
+      clientMutationId(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      }
+    }
+  },
   DeleteProfileByIdInput: {
     plans: {
       clientMutationId(qb, val) {
@@ -5419,14 +6887,14 @@ export const inputObjects = {
       }
     }
   },
-  DeleteTagByEntityKindAndEntityIdAndTagInput: {
+  DeleteProfileTagByEntityKindAndEntityIdAndTagInput: {
     plans: {
       clientMutationId(qb, val) {
         qb.setMeta("clientMutationId", val);
       }
     }
   },
-  DeleteTagInput: {
+  DeleteProfileTagInput: {
     plans: {
       clientMutationId(qb, val) {
         qb.setMeta("clientMutationId", val);
@@ -5479,6 +6947,83 @@ export const inputObjects = {
         schema
       }) {
         obj.set("id", bakedInputRuntime(schema, field.type, val));
+      }
+    }
+  },
+  LocationTagCondition: {
+    plans: {
+      entityId($condition, val) {
+        $condition.where({
+          type: "attribute",
+          attribute: "entity_id",
+          callback(expression) {
+            return val === null ? sql`${expression} is null` : sql`${expression} = ${sqlValueWithCodec(val, TYPES.uuid)}`;
+          }
+        });
+      },
+      entityKind($condition, val) {
+        $condition.where({
+          type: "attribute",
+          attribute: "entity_kind",
+          callback(expression) {
+            return val === null ? sql`${expression} is null` : sql`${expression} = ${sqlValueWithCodec(val, spec_locationTags_attributes_entity_kind_codec_EntityKindsEnum)}`;
+          }
+        });
+      },
+      tag($condition, val) {
+        $condition.where({
+          type: "attribute",
+          attribute: "tag",
+          callback(expression) {
+            return val === null ? sql`${expression} is null` : sql`${expression} = ${sqlValueWithCodec(val, TYPES.citext)}`;
+          }
+        });
+      }
+    }
+  },
+  LocationTagInput: {
+    baked: createObjectAndApplyChildren,
+    plans: {
+      entityId(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("entity_id", bakedInputRuntime(schema, field.type, val));
+      },
+      entityKind(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("entity_kind", bakedInputRuntime(schema, field.type, val));
+      },
+      tag(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("tag", bakedInputRuntime(schema, field.type, val));
+      }
+    }
+  },
+  LocationTagPatch: {
+    baked: createObjectAndApplyChildren,
+    plans: {
+      entityId(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("entity_id", bakedInputRuntime(schema, field.type, val));
+      },
+      entityKind(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("entity_kind", bakedInputRuntime(schema, field.type, val));
+      },
+      tag(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("tag", bakedInputRuntime(schema, field.type, val));
       }
     }
   },
@@ -5615,6 +7160,83 @@ export const inputObjects = {
       }
     }
   },
+  PhotoTagCondition: {
+    plans: {
+      entityId($condition, val) {
+        $condition.where({
+          type: "attribute",
+          attribute: "entity_id",
+          callback(expression) {
+            return val === null ? sql`${expression} is null` : sql`${expression} = ${sqlValueWithCodec(val, TYPES.uuid)}`;
+          }
+        });
+      },
+      entityKind($condition, val) {
+        $condition.where({
+          type: "attribute",
+          attribute: "entity_kind",
+          callback(expression) {
+            return val === null ? sql`${expression} is null` : sql`${expression} = ${sqlValueWithCodec(val, spec_locationTags_attributes_entity_kind_codec_EntityKindsEnum)}`;
+          }
+        });
+      },
+      tag($condition, val) {
+        $condition.where({
+          type: "attribute",
+          attribute: "tag",
+          callback(expression) {
+            return val === null ? sql`${expression} is null` : sql`${expression} = ${sqlValueWithCodec(val, TYPES.citext)}`;
+          }
+        });
+      }
+    }
+  },
+  PhotoTagInput: {
+    baked: createObjectAndApplyChildren,
+    plans: {
+      entityId(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("entity_id", bakedInputRuntime(schema, field.type, val));
+      },
+      entityKind(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("entity_kind", bakedInputRuntime(schema, field.type, val));
+      },
+      tag(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("tag", bakedInputRuntime(schema, field.type, val));
+      }
+    }
+  },
+  PhotoTagPatch: {
+    baked: createObjectAndApplyChildren,
+    plans: {
+      entityId(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("entity_id", bakedInputRuntime(schema, field.type, val));
+      },
+      entityKind(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("entity_kind", bakedInputRuntime(schema, field.type, val));
+      },
+      tag(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("tag", bakedInputRuntime(schema, field.type, val));
+      }
+    }
+  },
   ProfileCondition: {
     plans: {
       id($condition, val) {
@@ -5650,7 +7272,7 @@ export const inputObjects = {
       }
     }
   },
-  TagCondition: {
+  ProfileTagCondition: {
     plans: {
       entityId($condition, val) {
         $condition.where({
@@ -5681,7 +7303,7 @@ export const inputObjects = {
       }
     }
   },
-  TagInput: {
+  ProfileTagInput: {
     baked: createObjectAndApplyChildren,
     plans: {
       entityId(obj, val, {
@@ -5704,7 +7326,7 @@ export const inputObjects = {
       }
     }
   },
-  TagPatch: {
+  ProfileTagPatch: {
     baked: createObjectAndApplyChildren,
     plans: {
       entityId(obj, val, {
@@ -5745,6 +7367,30 @@ export const inputObjects = {
         qb.setMeta("clientMutationId", val);
       },
       locationPatch(qb, arg) {
+        if (arg != null) {
+          return qb.setBuilder();
+        }
+      }
+    }
+  },
+  UpdateLocationTagByEntityKindAndEntityIdAndTagInput: {
+    plans: {
+      clientMutationId(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      },
+      locationTagPatch(qb, arg) {
+        if (arg != null) {
+          return qb.setBuilder();
+        }
+      }
+    }
+  },
+  UpdateLocationTagInput: {
+    plans: {
+      clientMutationId(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      },
+      locationTagPatch(qb, arg) {
         if (arg != null) {
           return qb.setBuilder();
         }
@@ -5799,6 +7445,30 @@ export const inputObjects = {
       }
     }
   },
+  UpdatePhotoTagByEntityKindAndEntityIdAndTagInput: {
+    plans: {
+      clientMutationId(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      },
+      photoTagPatch(qb, arg) {
+        if (arg != null) {
+          return qb.setBuilder();
+        }
+      }
+    }
+  },
+  UpdatePhotoTagInput: {
+    plans: {
+      clientMutationId(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      },
+      photoTagPatch(qb, arg) {
+        if (arg != null) {
+          return qb.setBuilder();
+        }
+      }
+    }
+  },
   UpdateProfileByIdInput: {
     plans: {
       clientMutationId(qb, val) {
@@ -5823,24 +7493,24 @@ export const inputObjects = {
       }
     }
   },
-  UpdateTagByEntityKindAndEntityIdAndTagInput: {
+  UpdateProfileTagByEntityKindAndEntityIdAndTagInput: {
     plans: {
       clientMutationId(qb, val) {
         qb.setMeta("clientMutationId", val);
       },
-      tagPatch(qb, arg) {
+      profileTagPatch(qb, arg) {
         if (arg != null) {
           return qb.setBuilder();
         }
       }
     }
   },
-  UpdateTagInput: {
+  UpdateProfileTagInput: {
     plans: {
       clientMutationId(qb, val) {
         qb.setMeta("clientMutationId", val);
       },
-      tagPatch(qb, arg) {
+      profileTagPatch(qb, arg) {
         if (arg != null) {
           return qb.setBuilder();
         }
@@ -6013,6 +7683,66 @@ export const enums = {
       }
     }
   },
+  LocationTagsOrderBy: {
+    values: {
+      ENTITY_ID_ASC(queryBuilder) {
+        queryBuilder.orderBy({
+          attribute: "entity_id",
+          direction: "ASC"
+        });
+      },
+      ENTITY_ID_DESC(queryBuilder) {
+        queryBuilder.orderBy({
+          attribute: "entity_id",
+          direction: "DESC"
+        });
+      },
+      ENTITY_KIND_ASC(queryBuilder) {
+        queryBuilder.orderBy({
+          attribute: "entity_kind",
+          direction: "ASC"
+        });
+        queryBuilder.setOrderIsUnique();
+      },
+      ENTITY_KIND_DESC(queryBuilder) {
+        queryBuilder.orderBy({
+          attribute: "entity_kind",
+          direction: "DESC"
+        });
+        queryBuilder.setOrderIsUnique();
+      },
+      PRIMARY_KEY_ASC(queryBuilder) {
+        location_tagsUniques[0].attributes.forEach(attributeName => {
+          queryBuilder.orderBy({
+            attribute: attributeName,
+            direction: "ASC"
+          });
+        });
+        queryBuilder.setOrderIsUnique();
+      },
+      PRIMARY_KEY_DESC(queryBuilder) {
+        location_tagsUniques[0].attributes.forEach(attributeName => {
+          queryBuilder.orderBy({
+            attribute: attributeName,
+            direction: "DESC"
+          });
+        });
+        queryBuilder.setOrderIsUnique();
+      },
+      TAG_ASC(queryBuilder) {
+        queryBuilder.orderBy({
+          attribute: "tag",
+          direction: "ASC"
+        });
+      },
+      TAG_DESC(queryBuilder) {
+        queryBuilder.orderBy({
+          attribute: "tag",
+          direction: "DESC"
+        });
+      }
+    }
+  },
   MeasurementsOrderBy: {
     values: {
       KEY_ASC(queryBuilder) {
@@ -6121,6 +7851,66 @@ export const enums = {
       }
     }
   },
+  PhotoTagsOrderBy: {
+    values: {
+      ENTITY_ID_ASC(queryBuilder) {
+        queryBuilder.orderBy({
+          attribute: "entity_id",
+          direction: "ASC"
+        });
+      },
+      ENTITY_ID_DESC(queryBuilder) {
+        queryBuilder.orderBy({
+          attribute: "entity_id",
+          direction: "DESC"
+        });
+      },
+      ENTITY_KIND_ASC(queryBuilder) {
+        queryBuilder.orderBy({
+          attribute: "entity_kind",
+          direction: "ASC"
+        });
+        queryBuilder.setOrderIsUnique();
+      },
+      ENTITY_KIND_DESC(queryBuilder) {
+        queryBuilder.orderBy({
+          attribute: "entity_kind",
+          direction: "DESC"
+        });
+        queryBuilder.setOrderIsUnique();
+      },
+      PRIMARY_KEY_ASC(queryBuilder) {
+        photo_tagsUniques[0].attributes.forEach(attributeName => {
+          queryBuilder.orderBy({
+            attribute: attributeName,
+            direction: "ASC"
+          });
+        });
+        queryBuilder.setOrderIsUnique();
+      },
+      PRIMARY_KEY_DESC(queryBuilder) {
+        photo_tagsUniques[0].attributes.forEach(attributeName => {
+          queryBuilder.orderBy({
+            attribute: attributeName,
+            direction: "DESC"
+          });
+        });
+        queryBuilder.setOrderIsUnique();
+      },
+      TAG_ASC(queryBuilder) {
+        queryBuilder.orderBy({
+          attribute: "tag",
+          direction: "ASC"
+        });
+      },
+      TAG_DESC(queryBuilder) {
+        queryBuilder.orderBy({
+          attribute: "tag",
+          direction: "DESC"
+        });
+      }
+    }
+  },
   ProfilesOrderBy: {
     values: {
       ID_ASC(queryBuilder) {
@@ -6157,7 +7947,7 @@ export const enums = {
       }
     }
   },
-  TagsOrderBy: {
+  ProfileTagsOrderBy: {
     values: {
       ENTITY_ID_ASC(queryBuilder) {
         queryBuilder.orderBy({
@@ -6186,7 +7976,7 @@ export const enums = {
         queryBuilder.setOrderIsUnique();
       },
       PRIMARY_KEY_ASC(queryBuilder) {
-        tagsUniques[0].attributes.forEach(attributeName => {
+        profile_tagsUniques[0].attributes.forEach(attributeName => {
           queryBuilder.orderBy({
             attribute: attributeName,
             direction: "ASC"
@@ -6195,7 +7985,7 @@ export const enums = {
         queryBuilder.setOrderIsUnique();
       },
       PRIMARY_KEY_DESC(queryBuilder) {
-        tagsUniques[0].attributes.forEach(attributeName => {
+        profile_tagsUniques[0].attributes.forEach(attributeName => {
           queryBuilder.orderBy({
             attribute: attributeName,
             direction: "DESC"

--- a/postgraphile/postgraphile/__tests__/schema/v4/partitions.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/partitions.1.graphql
@@ -1,3 +1,38 @@
+"""All input for the create `Location` mutation."""
+input CreateLocationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The `Location` to be created by this mutation."""
+  location: LocationInput!
+}
+
+"""The output of our create `Location` mutation."""
+type CreateLocationPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Location` that was created by this mutation."""
+  location: Location
+
+  """An edge for our `Location`. May be used by Relay 1."""
+  locationEdge(
+    """The method to use when ordering `Location`."""
+    orderBy: [LocationsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): LocationsEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
 """All input for the create `Measurement` mutation."""
 input CreateMeasurementInput {
   """
@@ -34,6 +69,111 @@ type CreateMeasurementPayload {
 
   """Reads a single `User` that is related to this `Measurement`."""
   userByUserId: User
+}
+
+"""All input for the create `Photo` mutation."""
+input CreatePhotoInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The `Photo` to be created by this mutation."""
+  photo: PhotoInput!
+}
+
+"""The output of our create `Photo` mutation."""
+type CreatePhotoPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Photo` that was created by this mutation."""
+  photo: Photo
+
+  """An edge for our `Photo`. May be used by Relay 1."""
+  photoEdge(
+    """The method to use when ordering `Photo`."""
+    orderBy: [PhotosOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): PhotosEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the create `Profile` mutation."""
+input CreateProfileInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The `Profile` to be created by this mutation."""
+  profile: ProfileInput!
+}
+
+"""The output of our create `Profile` mutation."""
+type CreateProfilePayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Profile` that was created by this mutation."""
+  profile: Profile
+
+  """An edge for our `Profile`. May be used by Relay 1."""
+  profileEdge(
+    """The method to use when ordering `Profile`."""
+    orderBy: [ProfilesOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): ProfilesEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the create `Tag` mutation."""
+input CreateTagInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The `Tag` to be created by this mutation."""
+  tag: TagInput!
+}
+
+"""The output of our create `Tag` mutation."""
+type CreateTagPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """The `Tag` that was created by this mutation."""
+  tag: Tag
+
+  """An edge for our `Tag`. May be used by Relay 1."""
+  tagEdge(
+    """The method to use when ordering `Tag`."""
+    orderBy: [TagsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): TagsEdge
 }
 
 """All input for the create `User` mutation."""
@@ -82,6 +222,54 @@ that do not conform to both ISO 8601 and RFC 3339 may be coerced, which may lead
 to unexpected results.
 """
 scalar Datetime
+
+"""All input for the `deleteLocationById` mutation."""
+input DeleteLocationByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: UUID!
+}
+
+"""All input for the `deleteLocation` mutation."""
+input DeleteLocationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Location` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete `Location` mutation."""
+type DeleteLocationPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  deletedLocationId: ID
+
+  """The `Location` that was deleted by this mutation."""
+  location: Location
+
+  """An edge for our `Location`. May be used by Relay 1."""
+  locationEdge(
+    """The method to use when ordering `Location`."""
+    orderBy: [LocationsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): LocationsEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
 
 """All input for the `deleteMeasurementByTimestampAndKey` mutation."""
 input DeleteMeasurementByTimestampAndKeyInput {
@@ -135,6 +323,152 @@ type DeleteMeasurementPayload {
   userByUserId: User
 }
 
+"""All input for the `deletePhotoById` mutation."""
+input DeletePhotoByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: UUID!
+}
+
+"""All input for the `deletePhoto` mutation."""
+input DeletePhotoInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Photo` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete `Photo` mutation."""
+type DeletePhotoPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  deletedPhotoId: ID
+
+  """The `Photo` that was deleted by this mutation."""
+  photo: Photo
+
+  """An edge for our `Photo`. May be used by Relay 1."""
+  photoEdge(
+    """The method to use when ordering `Photo`."""
+    orderBy: [PhotosOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): PhotosEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the `deleteProfileById` mutation."""
+input DeleteProfileByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: UUID!
+}
+
+"""All input for the `deleteProfile` mutation."""
+input DeleteProfileInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Profile` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete `Profile` mutation."""
+type DeleteProfilePayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  deletedProfileId: ID
+
+  """The `Profile` that was deleted by this mutation."""
+  profile: Profile
+
+  """An edge for our `Profile`. May be used by Relay 1."""
+  profileEdge(
+    """The method to use when ordering `Profile`."""
+    orderBy: [ProfilesOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): ProfilesEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the `deleteTagByEntityKindAndEntityIdAndTag` mutation."""
+input DeleteTagByEntityKindAndEntityIdAndTagInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  entityId: UUID!
+  entityKind: EntityKinds!
+  tag: String!
+}
+
+"""All input for the `deleteTag` mutation."""
+input DeleteTagInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Tag` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete `Tag` mutation."""
+type DeleteTagPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  deletedTagId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """The `Tag` that was deleted by this mutation."""
+  tag: Tag
+
+  """An edge for our `Tag`. May be used by Relay 1."""
+  tagEdge(
+    """The method to use when ordering `Tag`."""
+    orderBy: [TagsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): TagsEdge
+}
+
 """All input for the `deleteUserById` mutation."""
 input DeleteUserByIdInput {
   """
@@ -181,6 +515,77 @@ type DeleteUserPayload {
     """The method to use when ordering `User`."""
     orderBy: [UsersOrderBy!]! = [PRIMARY_KEY_ASC]
   ): UsersEdge
+}
+
+enum EntityKinds {
+  LOCATIONS
+  PHOTOS
+  PROFILES
+}
+
+type Location implements Node {
+  id: UUID!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+}
+
+"""
+A condition to be used against `Location` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input LocationCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: UUID
+}
+
+"""An input for mutations affecting `Location`"""
+input LocationInput {
+  id: UUID!
+}
+
+"""
+Represents an update to a `Location`. Fields that are set will be updated.
+"""
+input LocationPatch {
+  id: UUID
+}
+
+"""A connection to a list of `Location` values."""
+type LocationsConnection {
+  """
+  A list of edges which contains the `Location` and cursor to aid in pagination.
+  """
+  edges: [LocationsEdge]!
+
+  """A list of `Location` objects."""
+  nodes: [Location]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Location` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `Location` edge in the connection."""
+type LocationsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Location` at the end of the edge."""
+  node: Location
+}
+
+"""Methods to use when ordering `Location`."""
+enum LocationsOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
 }
 
 type Measurement implements Node {
@@ -279,6 +684,14 @@ enum MeasurementsOrderBy {
 The root mutation type which contains root level fields which mutate data.
 """
 type Mutation {
+  """Creates a single `Location`."""
+  createLocation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateLocationInput!
+  ): CreateLocationPayload
+
   """Creates a single `Measurement`."""
   createMeasurement(
     """
@@ -287,6 +700,30 @@ type Mutation {
     input: CreateMeasurementInput!
   ): CreateMeasurementPayload
 
+  """Creates a single `Photo`."""
+  createPhoto(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreatePhotoInput!
+  ): CreatePhotoPayload
+
+  """Creates a single `Profile`."""
+  createProfile(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateProfileInput!
+  ): CreateProfilePayload
+
+  """Creates a single `Tag`."""
+  createTag(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateTagInput!
+  ): CreateTagPayload
+
   """Creates a single `User`."""
   createUser(
     """
@@ -294,6 +731,22 @@ type Mutation {
     """
     input: CreateUserInput!
   ): CreateUserPayload
+
+  """Deletes a single `Location` using its globally unique id."""
+  deleteLocation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteLocationInput!
+  ): DeleteLocationPayload
+
+  """Deletes a single `Location` using a unique key."""
+  deleteLocationById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteLocationByIdInput!
+  ): DeleteLocationPayload
 
   """Deletes a single `Measurement` using its globally unique id."""
   deleteMeasurement(
@@ -311,6 +764,54 @@ type Mutation {
     input: DeleteMeasurementByTimestampAndKeyInput!
   ): DeleteMeasurementPayload
 
+  """Deletes a single `Photo` using its globally unique id."""
+  deletePhoto(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeletePhotoInput!
+  ): DeletePhotoPayload
+
+  """Deletes a single `Photo` using a unique key."""
+  deletePhotoById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeletePhotoByIdInput!
+  ): DeletePhotoPayload
+
+  """Deletes a single `Profile` using its globally unique id."""
+  deleteProfile(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteProfileInput!
+  ): DeleteProfilePayload
+
+  """Deletes a single `Profile` using a unique key."""
+  deleteProfileById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteProfileByIdInput!
+  ): DeleteProfilePayload
+
+  """Deletes a single `Tag` using its globally unique id."""
+  deleteTag(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteTagInput!
+  ): DeleteTagPayload
+
+  """Deletes a single `Tag` using a unique key."""
+  deleteTagByEntityKindAndEntityIdAndTag(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteTagByEntityKindAndEntityIdAndTagInput!
+  ): DeleteTagPayload
+
   """Deletes a single `User` using its globally unique id."""
   deleteUser(
     """
@@ -326,6 +827,22 @@ type Mutation {
     """
     input: DeleteUserByIdInput!
   ): DeleteUserPayload
+
+  """Updates a single `Location` using its globally unique id and a patch."""
+  updateLocation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateLocationInput!
+  ): UpdateLocationPayload
+
+  """Updates a single `Location` using a unique key and a patch."""
+  updateLocationById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateLocationByIdInput!
+  ): UpdateLocationPayload
 
   """
   Updates a single `Measurement` using its globally unique id and a patch.
@@ -344,6 +861,54 @@ type Mutation {
     """
     input: UpdateMeasurementByTimestampAndKeyInput!
   ): UpdateMeasurementPayload
+
+  """Updates a single `Photo` using its globally unique id and a patch."""
+  updatePhoto(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdatePhotoInput!
+  ): UpdatePhotoPayload
+
+  """Updates a single `Photo` using a unique key and a patch."""
+  updatePhotoById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdatePhotoByIdInput!
+  ): UpdatePhotoPayload
+
+  """Updates a single `Profile` using its globally unique id and a patch."""
+  updateProfile(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateProfileInput!
+  ): UpdateProfilePayload
+
+  """Updates a single `Profile` using a unique key and a patch."""
+  updateProfileById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateProfileByIdInput!
+  ): UpdateProfilePayload
+
+  """Updates a single `Tag` using its globally unique id and a patch."""
+  updateTag(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateTagInput!
+  ): UpdateTagPayload
+
+  """Updates a single `Tag` using a unique key and a patch."""
+  updateTagByEntityKindAndEntityIdAndTag(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateTagByEntityKindAndEntityIdAndTagInput!
+  ): UpdateTagPayload
 
   """Updates a single `User` using its globally unique id and a patch."""
   updateUser(
@@ -385,8 +950,165 @@ type PageInfo {
   startCursor: Cursor
 }
 
+type Photo implements Node {
+  id: UUID!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+}
+
+"""
+A condition to be used against `Photo` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input PhotoCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: UUID
+}
+
+"""An input for mutations affecting `Photo`"""
+input PhotoInput {
+  id: UUID!
+}
+
+"""
+Represents an update to a `Photo`. Fields that are set will be updated.
+"""
+input PhotoPatch {
+  id: UUID
+}
+
+"""A connection to a list of `Photo` values."""
+type PhotosConnection {
+  """
+  A list of edges which contains the `Photo` and cursor to aid in pagination.
+  """
+  edges: [PhotosEdge]!
+
+  """A list of `Photo` objects."""
+  nodes: [Photo]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Photo` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `Photo` edge in the connection."""
+type PhotosEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Photo` at the end of the edge."""
+  node: Photo
+}
+
+"""Methods to use when ordering `Photo`."""
+enum PhotosOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+type Profile implements Node {
+  id: UUID!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+}
+
+"""
+A condition to be used against `Profile` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input ProfileCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: UUID
+}
+
+"""An input for mutations affecting `Profile`"""
+input ProfileInput {
+  id: UUID!
+}
+
+"""
+Represents an update to a `Profile`. Fields that are set will be updated.
+"""
+input ProfilePatch {
+  id: UUID
+}
+
+"""A connection to a list of `Profile` values."""
+type ProfilesConnection {
+  """
+  A list of edges which contains the `Profile` and cursor to aid in pagination.
+  """
+  edges: [ProfilesEdge]!
+
+  """A list of `Profile` objects."""
+  nodes: [Profile]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Profile` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `Profile` edge in the connection."""
+type ProfilesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Profile` at the end of the edge."""
+  node: Profile
+}
+
+"""Methods to use when ordering `Profile`."""
+enum ProfilesOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
 """The root query type which gives access points into the data universe."""
 type Query implements Node {
+  """Reads and enables pagination through a set of `Location`."""
+  allLocations(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: LocationCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `Location`."""
+    orderBy: [LocationsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LocationsConnection
+
   """Reads and enables pagination through a set of `Measurement`."""
   allMeasurements(
     """Read all values in the set after (below) this cursor."""
@@ -415,6 +1137,93 @@ type Query implements Node {
     """The method to use when ordering `Measurement`."""
     orderBy: [MeasurementsOrderBy!] = [PRIMARY_KEY_ASC]
   ): MeasurementsConnection
+
+  """Reads and enables pagination through a set of `Photo`."""
+  allPhotos(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PhotoCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `Photo`."""
+    orderBy: [PhotosOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PhotosConnection
+
+  """Reads and enables pagination through a set of `Profile`."""
+  allProfiles(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProfileCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `Profile`."""
+    orderBy: [ProfilesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProfilesConnection
+
+  """Reads and enables pagination through a set of `Tag`."""
+  allTags(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TagCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `Tag`."""
+    orderBy: [TagsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): TagsConnection
 
   """Reads and enables pagination through a set of `User`."""
   allUsers(
@@ -445,6 +1254,15 @@ type Query implements Node {
     orderBy: [UsersOrderBy!] = [PRIMARY_KEY_ASC]
   ): UsersConnection
 
+  """Reads a single `Location` using its globally unique `ID`."""
+  location(
+    """The globally unique `ID` to be used in selecting a single `Location`."""
+    nodeId: ID!
+  ): Location
+
+  """Get a single `Location`."""
+  locationById(id: UUID!): Location
+
   """Reads a single `Measurement` using its globally unique `ID`."""
   measurement(
     """
@@ -467,11 +1285,38 @@ type Query implements Node {
   """
   nodeId: ID!
 
+  """Reads a single `Photo` using its globally unique `ID`."""
+  photo(
+    """The globally unique `ID` to be used in selecting a single `Photo`."""
+    nodeId: ID!
+  ): Photo
+
+  """Get a single `Photo`."""
+  photoById(id: UUID!): Photo
+
+  """Reads a single `Profile` using its globally unique `ID`."""
+  profile(
+    """The globally unique `ID` to be used in selecting a single `Profile`."""
+    nodeId: ID!
+  ): Profile
+
+  """Get a single `Profile`."""
+  profileById(id: UUID!): Profile
+
   """
   Exposes the root query type nested one level down. This is helpful for Relay 1
   which can only query top level fields if they are in a particular form.
   """
   query: Query!
+
+  """Reads a single `Tag` using its globally unique `ID`."""
+  tag(
+    """The globally unique `ID` to be used in selecting a single `Tag`."""
+    nodeId: ID!
+  ): Tag
+
+  """Get a single `Tag`."""
+  tagByEntityKindAndEntityIdAndTag(entityId: UUID!, entityKind: EntityKinds!, tag: String!): Tag
 
   """Reads a single `User` using its globally unique `ID`."""
   user(
@@ -481,6 +1326,146 @@ type Query implements Node {
 
   """Get a single `User`."""
   userById(id: Int!): User
+}
+
+type Tag implements Node {
+  entityId: UUID!
+  entityKind: EntityKinds!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  tag: String!
+}
+
+"""
+A condition to be used against `Tag` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input TagCondition {
+  """Checks for equality with the object’s `entityId` field."""
+  entityId: UUID
+
+  """Checks for equality with the object’s `entityKind` field."""
+  entityKind: EntityKinds
+
+  """Checks for equality with the object’s `tag` field."""
+  tag: String
+}
+
+"""An input for mutations affecting `Tag`"""
+input TagInput {
+  entityId: UUID!
+  entityKind: EntityKinds!
+  tag: String!
+}
+
+"""Represents an update to a `Tag`. Fields that are set will be updated."""
+input TagPatch {
+  entityId: UUID
+  entityKind: EntityKinds
+  tag: String
+}
+
+"""A connection to a list of `Tag` values."""
+type TagsConnection {
+  """
+  A list of edges which contains the `Tag` and cursor to aid in pagination.
+  """
+  edges: [TagsEdge]!
+
+  """A list of `Tag` objects."""
+  nodes: [Tag]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Tag` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `Tag` edge in the connection."""
+type TagsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Tag` at the end of the edge."""
+  node: Tag
+}
+
+"""Methods to use when ordering `Tag`."""
+enum TagsOrderBy {
+  ENTITY_ID_ASC
+  ENTITY_ID_DESC
+  ENTITY_KIND_ASC
+  ENTITY_KIND_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  TAG_ASC
+  TAG_DESC
+}
+
+"""
+A universally unique identifier as defined by [RFC 4122](https://tools.ietf.org/html/rfc4122).
+"""
+scalar UUID
+
+"""All input for the `updateLocationById` mutation."""
+input UpdateLocationByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: UUID!
+
+  """
+  An object where the defined keys will be set on the `Location` being updated.
+  """
+  locationPatch: LocationPatch!
+}
+
+"""All input for the `updateLocation` mutation."""
+input UpdateLocationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `Location` being updated.
+  """
+  locationPatch: LocationPatch!
+
+  """
+  The globally unique `ID` which will identify a single `Location` to be updated.
+  """
+  nodeId: ID!
+}
+
+"""The output of our update `Location` mutation."""
+type UpdateLocationPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Location` that was updated by this mutation."""
+  location: Location
+
+  """An edge for our `Location`. May be used by Relay 1."""
+  locationEdge(
+    """The method to use when ordering `Location`."""
+    orderBy: [LocationsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): LocationsEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
 }
 
 """All input for the `updateMeasurementByTimestampAndKey` mutation."""
@@ -542,6 +1527,179 @@ type UpdateMeasurementPayload {
 
   """Reads a single `User` that is related to this `Measurement`."""
   userByUserId: User
+}
+
+"""All input for the `updatePhotoById` mutation."""
+input UpdatePhotoByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: UUID!
+
+  """
+  An object where the defined keys will be set on the `Photo` being updated.
+  """
+  photoPatch: PhotoPatch!
+}
+
+"""All input for the `updatePhoto` mutation."""
+input UpdatePhotoInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Photo` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the `Photo` being updated.
+  """
+  photoPatch: PhotoPatch!
+}
+
+"""The output of our update `Photo` mutation."""
+type UpdatePhotoPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Photo` that was updated by this mutation."""
+  photo: Photo
+
+  """An edge for our `Photo`. May be used by Relay 1."""
+  photoEdge(
+    """The method to use when ordering `Photo`."""
+    orderBy: [PhotosOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): PhotosEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the `updateProfileById` mutation."""
+input UpdateProfileByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: UUID!
+
+  """
+  An object where the defined keys will be set on the `Profile` being updated.
+  """
+  profilePatch: ProfilePatch!
+}
+
+"""All input for the `updateProfile` mutation."""
+input UpdateProfileInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Profile` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the `Profile` being updated.
+  """
+  profilePatch: ProfilePatch!
+}
+
+"""The output of our update `Profile` mutation."""
+type UpdateProfilePayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Profile` that was updated by this mutation."""
+  profile: Profile
+
+  """An edge for our `Profile`. May be used by Relay 1."""
+  profileEdge(
+    """The method to use when ordering `Profile`."""
+    orderBy: [ProfilesOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): ProfilesEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the `updateTagByEntityKindAndEntityIdAndTag` mutation."""
+input UpdateTagByEntityKindAndEntityIdAndTagInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  entityId: UUID!
+  entityKind: EntityKinds!
+  tag: String!
+
+  """
+  An object where the defined keys will be set on the `Tag` being updated.
+  """
+  tagPatch: TagPatch!
+}
+
+"""All input for the `updateTag` mutation."""
+input UpdateTagInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Tag` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the `Tag` being updated.
+  """
+  tagPatch: TagPatch!
+}
+
+"""The output of our update `Tag` mutation."""
+type UpdateTagPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """The `Tag` that was updated by this mutation."""
+  tag: Tag
+
+  """An edge for our `Tag`. May be used by Relay 1."""
+  tagEdge(
+    """The method to use when ordering `Tag`."""
+    orderBy: [TagsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): TagsEdge
 }
 
 """All input for the `updateUserById` mutation."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/partitions.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/partitions.1.graphql
@@ -33,6 +33,44 @@ type CreateLocationPayload {
   query: Query
 }
 
+"""All input for the create `LocationTag` mutation."""
+input CreateLocationTagInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The `LocationTag` to be created by this mutation."""
+  locationTag: LocationTagInput!
+}
+
+"""The output of our create `LocationTag` mutation."""
+type CreateLocationTagPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """Reads a single `Location` that is related to this `LocationTag`."""
+  locationByEntityId: Location
+
+  """The `LocationTag` that was created by this mutation."""
+  locationTag: LocationTag
+
+  """An edge for our `LocationTag`. May be used by Relay 1."""
+  locationTagEdge(
+    """The method to use when ordering `LocationTag`."""
+    orderBy: [LocationTagsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): LocationTagsEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
 """All input for the create `Measurement` mutation."""
 input CreateMeasurementInput {
   """
@@ -106,6 +144,44 @@ type CreatePhotoPayload {
   query: Query
 }
 
+"""All input for the create `PhotoTag` mutation."""
+input CreatePhotoTagInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The `PhotoTag` to be created by this mutation."""
+  photoTag: PhotoTagInput!
+}
+
+"""The output of our create `PhotoTag` mutation."""
+type CreatePhotoTagPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """Reads a single `Photo` that is related to this `PhotoTag`."""
+  photoByEntityId: Photo
+
+  """The `PhotoTag` that was created by this mutation."""
+  photoTag: PhotoTag
+
+  """An edge for our `PhotoTag`. May be used by Relay 1."""
+  photoTagEdge(
+    """The method to use when ordering `PhotoTag`."""
+    orderBy: [PhotoTagsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): PhotoTagsEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
 """All input for the create `Profile` mutation."""
 input CreateProfileInput {
   """
@@ -141,39 +217,42 @@ type CreateProfilePayload {
   query: Query
 }
 
-"""All input for the create `Tag` mutation."""
-input CreateTagInput {
+"""All input for the create `ProfileTag` mutation."""
+input CreateProfileTagInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
   """
   clientMutationId: String
 
-  """The `Tag` to be created by this mutation."""
-  tag: TagInput!
+  """The `ProfileTag` to be created by this mutation."""
+  profileTag: ProfileTagInput!
 }
 
-"""The output of our create `Tag` mutation."""
-type CreateTagPayload {
+"""The output of our create `ProfileTag` mutation."""
+type CreateProfileTagPayload {
   """
   The exact same `clientMutationId` that was provided in the mutation input,
   unchanged and unused. May be used by a client to track mutations.
   """
   clientMutationId: String
 
+  """Reads a single `Profile` that is related to this `ProfileTag`."""
+  profileByEntityId: Profile
+
+  """The `ProfileTag` that was created by this mutation."""
+  profileTag: ProfileTag
+
+  """An edge for our `ProfileTag`. May be used by Relay 1."""
+  profileTagEdge(
+    """The method to use when ordering `ProfileTag`."""
+    orderBy: [ProfileTagsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): ProfileTagsEdge
+
   """
   Our root query field type. Allows us to run any query from our mutation payload.
   """
   query: Query
-
-  """The `Tag` that was created by this mutation."""
-  tag: Tag
-
-  """An edge for our `Tag`. May be used by Relay 1."""
-  tagEdge(
-    """The method to use when ordering `Tag`."""
-    orderBy: [TagsOrderBy!]! = [PRIMARY_KEY_ASC]
-  ): TagsEdge
 }
 
 """All input for the create `User` mutation."""
@@ -264,6 +343,61 @@ type DeleteLocationPayload {
     """The method to use when ordering `Location`."""
     orderBy: [LocationsOrderBy!]! = [PRIMARY_KEY_ASC]
   ): LocationsEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""
+All input for the `deleteLocationTagByEntityKindAndEntityIdAndTag` mutation.
+"""
+input DeleteLocationTagByEntityKindAndEntityIdAndTagInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  entityId: UUID!
+  entityKind: EntityKinds!
+  tag: String!
+}
+
+"""All input for the `deleteLocationTag` mutation."""
+input DeleteLocationTagInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `LocationTag` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete `LocationTag` mutation."""
+type DeleteLocationTagPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  deletedLocationTagId: ID
+
+  """Reads a single `Location` that is related to this `LocationTag`."""
+  locationByEntityId: Location
+
+  """The `LocationTag` that was deleted by this mutation."""
+  locationTag: LocationTag
+
+  """An edge for our `LocationTag`. May be used by Relay 1."""
+  locationTagEdge(
+    """The method to use when ordering `LocationTag`."""
+    orderBy: [LocationTagsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): LocationTagsEdge
 
   """
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -371,6 +505,61 @@ type DeletePhotoPayload {
   query: Query
 }
 
+"""
+All input for the `deletePhotoTagByEntityKindAndEntityIdAndTag` mutation.
+"""
+input DeletePhotoTagByEntityKindAndEntityIdAndTagInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  entityId: UUID!
+  entityKind: EntityKinds!
+  tag: String!
+}
+
+"""All input for the `deletePhotoTag` mutation."""
+input DeletePhotoTagInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `PhotoTag` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete `PhotoTag` mutation."""
+type DeletePhotoTagPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  deletedPhotoTagId: ID
+
+  """Reads a single `Photo` that is related to this `PhotoTag`."""
+  photoByEntityId: Photo
+
+  """The `PhotoTag` that was deleted by this mutation."""
+  photoTag: PhotoTag
+
+  """An edge for our `PhotoTag`. May be used by Relay 1."""
+  photoTagEdge(
+    """The method to use when ordering `PhotoTag`."""
+    orderBy: [PhotoTagsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): PhotoTagsEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
 """All input for the `deleteProfileById` mutation."""
 input DeleteProfileByIdInput {
   """
@@ -419,8 +608,10 @@ type DeleteProfilePayload {
   query: Query
 }
 
-"""All input for the `deleteTagByEntityKindAndEntityIdAndTag` mutation."""
-input DeleteTagByEntityKindAndEntityIdAndTagInput {
+"""
+All input for the `deleteProfileTagByEntityKindAndEntityIdAndTag` mutation.
+"""
+input DeleteProfileTagByEntityKindAndEntityIdAndTagInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -431,8 +622,8 @@ input DeleteTagByEntityKindAndEntityIdAndTagInput {
   tag: String!
 }
 
-"""All input for the `deleteTag` mutation."""
-input DeleteTagInput {
+"""All input for the `deleteProfileTag` mutation."""
+input DeleteProfileTagInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -440,33 +631,36 @@ input DeleteTagInput {
   clientMutationId: String
 
   """
-  The globally unique `ID` which will identify a single `Tag` to be deleted.
+  The globally unique `ID` which will identify a single `ProfileTag` to be deleted.
   """
   nodeId: ID!
 }
 
-"""The output of our delete `Tag` mutation."""
-type DeleteTagPayload {
+"""The output of our delete `ProfileTag` mutation."""
+type DeleteProfileTagPayload {
   """
   The exact same `clientMutationId` that was provided in the mutation input,
   unchanged and unused. May be used by a client to track mutations.
   """
   clientMutationId: String
-  deletedTagId: ID
+  deletedProfileTagId: ID
+
+  """Reads a single `Profile` that is related to this `ProfileTag`."""
+  profileByEntityId: Profile
+
+  """The `ProfileTag` that was deleted by this mutation."""
+  profileTag: ProfileTag
+
+  """An edge for our `ProfileTag`. May be used by Relay 1."""
+  profileTagEdge(
+    """The method to use when ordering `ProfileTag`."""
+    orderBy: [ProfileTagsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): ProfileTagsEdge
 
   """
   Our root query field type. Allows us to run any query from our mutation payload.
   """
   query: Query
-
-  """The `Tag` that was deleted by this mutation."""
-  tag: Tag
-
-  """An edge for our `Tag`. May be used by Relay 1."""
-  tagEdge(
-    """The method to use when ordering `Tag`."""
-    orderBy: [TagsOrderBy!]! = [PRIMARY_KEY_ASC]
-  ): TagsEdge
 }
 
 """All input for the `deleteUserById` mutation."""
@@ -526,6 +720,35 @@ enum EntityKinds {
 type Location implements Node {
   id: UUID!
 
+  """Reads and enables pagination through a set of `LocationTag`."""
+  locationTagsByEntityId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: LocationTagCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `LocationTag`."""
+    orderBy: [LocationTagsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LocationTagsConnection!
+
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
@@ -551,6 +774,90 @@ Represents an update to a `Location`. Fields that are set will be updated.
 """
 input LocationPatch {
   id: UUID
+}
+
+type LocationTag implements Node {
+  entityId: UUID!
+  entityKind: EntityKinds!
+
+  """Reads a single `Location` that is related to this `LocationTag`."""
+  locationByEntityId: Location
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  tag: String!
+}
+
+"""
+A condition to be used against `LocationTag` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input LocationTagCondition {
+  """Checks for equality with the object’s `entityId` field."""
+  entityId: UUID
+
+  """Checks for equality with the object’s `entityKind` field."""
+  entityKind: EntityKinds
+
+  """Checks for equality with the object’s `tag` field."""
+  tag: String
+}
+
+"""An input for mutations affecting `LocationTag`"""
+input LocationTagInput {
+  entityId: UUID!
+  entityKind: EntityKinds!
+  tag: String!
+}
+
+"""
+Represents an update to a `LocationTag`. Fields that are set will be updated.
+"""
+input LocationTagPatch {
+  entityId: UUID
+  entityKind: EntityKinds
+  tag: String
+}
+
+"""A connection to a list of `LocationTag` values."""
+type LocationTagsConnection {
+  """
+  A list of edges which contains the `LocationTag` and cursor to aid in pagination.
+  """
+  edges: [LocationTagsEdge]!
+
+  """A list of `LocationTag` objects."""
+  nodes: [LocationTag]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `LocationTag` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `LocationTag` edge in the connection."""
+type LocationTagsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `LocationTag` at the end of the edge."""
+  node: LocationTag
+}
+
+"""Methods to use when ordering `LocationTag`."""
+enum LocationTagsOrderBy {
+  ENTITY_ID_ASC
+  ENTITY_ID_DESC
+  ENTITY_KIND_ASC
+  ENTITY_KIND_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  TAG_ASC
+  TAG_DESC
 }
 
 """A connection to a list of `Location` values."""
@@ -692,6 +999,14 @@ type Mutation {
     input: CreateLocationInput!
   ): CreateLocationPayload
 
+  """Creates a single `LocationTag`."""
+  createLocationTag(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateLocationTagInput!
+  ): CreateLocationTagPayload
+
   """Creates a single `Measurement`."""
   createMeasurement(
     """
@@ -708,6 +1023,14 @@ type Mutation {
     input: CreatePhotoInput!
   ): CreatePhotoPayload
 
+  """Creates a single `PhotoTag`."""
+  createPhotoTag(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreatePhotoTagInput!
+  ): CreatePhotoTagPayload
+
   """Creates a single `Profile`."""
   createProfile(
     """
@@ -716,13 +1039,13 @@ type Mutation {
     input: CreateProfileInput!
   ): CreateProfilePayload
 
-  """Creates a single `Tag`."""
-  createTag(
+  """Creates a single `ProfileTag`."""
+  createProfileTag(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: CreateTagInput!
-  ): CreateTagPayload
+    input: CreateProfileTagInput!
+  ): CreateProfileTagPayload
 
   """Creates a single `User`."""
   createUser(
@@ -747,6 +1070,22 @@ type Mutation {
     """
     input: DeleteLocationByIdInput!
   ): DeleteLocationPayload
+
+  """Deletes a single `LocationTag` using its globally unique id."""
+  deleteLocationTag(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteLocationTagInput!
+  ): DeleteLocationTagPayload
+
+  """Deletes a single `LocationTag` using a unique key."""
+  deleteLocationTagByEntityKindAndEntityIdAndTag(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteLocationTagByEntityKindAndEntityIdAndTagInput!
+  ): DeleteLocationTagPayload
 
   """Deletes a single `Measurement` using its globally unique id."""
   deleteMeasurement(
@@ -780,6 +1119,22 @@ type Mutation {
     input: DeletePhotoByIdInput!
   ): DeletePhotoPayload
 
+  """Deletes a single `PhotoTag` using its globally unique id."""
+  deletePhotoTag(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeletePhotoTagInput!
+  ): DeletePhotoTagPayload
+
+  """Deletes a single `PhotoTag` using a unique key."""
+  deletePhotoTagByEntityKindAndEntityIdAndTag(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeletePhotoTagByEntityKindAndEntityIdAndTagInput!
+  ): DeletePhotoTagPayload
+
   """Deletes a single `Profile` using its globally unique id."""
   deleteProfile(
     """
@@ -796,21 +1151,21 @@ type Mutation {
     input: DeleteProfileByIdInput!
   ): DeleteProfilePayload
 
-  """Deletes a single `Tag` using its globally unique id."""
-  deleteTag(
+  """Deletes a single `ProfileTag` using its globally unique id."""
+  deleteProfileTag(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: DeleteTagInput!
-  ): DeleteTagPayload
+    input: DeleteProfileTagInput!
+  ): DeleteProfileTagPayload
 
-  """Deletes a single `Tag` using a unique key."""
-  deleteTagByEntityKindAndEntityIdAndTag(
+  """Deletes a single `ProfileTag` using a unique key."""
+  deleteProfileTagByEntityKindAndEntityIdAndTag(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: DeleteTagByEntityKindAndEntityIdAndTagInput!
-  ): DeleteTagPayload
+    input: DeleteProfileTagByEntityKindAndEntityIdAndTagInput!
+  ): DeleteProfileTagPayload
 
   """Deletes a single `User` using its globally unique id."""
   deleteUser(
@@ -843,6 +1198,24 @@ type Mutation {
     """
     input: UpdateLocationByIdInput!
   ): UpdateLocationPayload
+
+  """
+  Updates a single `LocationTag` using its globally unique id and a patch.
+  """
+  updateLocationTag(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateLocationTagInput!
+  ): UpdateLocationTagPayload
+
+  """Updates a single `LocationTag` using a unique key and a patch."""
+  updateLocationTagByEntityKindAndEntityIdAndTag(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateLocationTagByEntityKindAndEntityIdAndTagInput!
+  ): UpdateLocationTagPayload
 
   """
   Updates a single `Measurement` using its globally unique id and a patch.
@@ -878,6 +1251,22 @@ type Mutation {
     input: UpdatePhotoByIdInput!
   ): UpdatePhotoPayload
 
+  """Updates a single `PhotoTag` using its globally unique id and a patch."""
+  updatePhotoTag(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdatePhotoTagInput!
+  ): UpdatePhotoTagPayload
+
+  """Updates a single `PhotoTag` using a unique key and a patch."""
+  updatePhotoTagByEntityKindAndEntityIdAndTag(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdatePhotoTagByEntityKindAndEntityIdAndTagInput!
+  ): UpdatePhotoTagPayload
+
   """Updates a single `Profile` using its globally unique id and a patch."""
   updateProfile(
     """
@@ -894,21 +1283,23 @@ type Mutation {
     input: UpdateProfileByIdInput!
   ): UpdateProfilePayload
 
-  """Updates a single `Tag` using its globally unique id and a patch."""
-  updateTag(
+  """
+  Updates a single `ProfileTag` using its globally unique id and a patch.
+  """
+  updateProfileTag(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: UpdateTagInput!
-  ): UpdateTagPayload
+    input: UpdateProfileTagInput!
+  ): UpdateProfileTagPayload
 
-  """Updates a single `Tag` using a unique key and a patch."""
-  updateTagByEntityKindAndEntityIdAndTag(
+  """Updates a single `ProfileTag` using a unique key and a patch."""
+  updateProfileTagByEntityKindAndEntityIdAndTag(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
     """
-    input: UpdateTagByEntityKindAndEntityIdAndTagInput!
-  ): UpdateTagPayload
+    input: UpdateProfileTagByEntityKindAndEntityIdAndTagInput!
+  ): UpdateProfileTagPayload
 
   """Updates a single `User` using its globally unique id and a patch."""
   updateUser(
@@ -957,6 +1348,35 @@ type Photo implements Node {
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
+
+  """Reads and enables pagination through a set of `PhotoTag`."""
+  photoTagsByEntityId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PhotoTagCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `PhotoTag`."""
+    orderBy: [PhotoTagsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PhotoTagsConnection!
 }
 
 """
@@ -977,6 +1397,90 @@ Represents an update to a `Photo`. Fields that are set will be updated.
 """
 input PhotoPatch {
   id: UUID
+}
+
+type PhotoTag implements Node {
+  entityId: UUID!
+  entityKind: EntityKinds!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+
+  """Reads a single `Photo` that is related to this `PhotoTag`."""
+  photoByEntityId: Photo
+  tag: String!
+}
+
+"""
+A condition to be used against `PhotoTag` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input PhotoTagCondition {
+  """Checks for equality with the object’s `entityId` field."""
+  entityId: UUID
+
+  """Checks for equality with the object’s `entityKind` field."""
+  entityKind: EntityKinds
+
+  """Checks for equality with the object’s `tag` field."""
+  tag: String
+}
+
+"""An input for mutations affecting `PhotoTag`"""
+input PhotoTagInput {
+  entityId: UUID!
+  entityKind: EntityKinds!
+  tag: String!
+}
+
+"""
+Represents an update to a `PhotoTag`. Fields that are set will be updated.
+"""
+input PhotoTagPatch {
+  entityId: UUID
+  entityKind: EntityKinds
+  tag: String
+}
+
+"""A connection to a list of `PhotoTag` values."""
+type PhotoTagsConnection {
+  """
+  A list of edges which contains the `PhotoTag` and cursor to aid in pagination.
+  """
+  edges: [PhotoTagsEdge]!
+
+  """A list of `PhotoTag` objects."""
+  nodes: [PhotoTag]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `PhotoTag` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `PhotoTag` edge in the connection."""
+type PhotoTagsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `PhotoTag` at the end of the edge."""
+  node: PhotoTag
+}
+
+"""Methods to use when ordering `PhotoTag`."""
+enum PhotoTagsOrderBy {
+  ENTITY_ID_ASC
+  ENTITY_ID_DESC
+  ENTITY_KIND_ASC
+  ENTITY_KIND_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  TAG_ASC
+  TAG_DESC
 }
 
 """A connection to a list of `Photo` values."""
@@ -1021,6 +1525,35 @@ type Profile implements Node {
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
+
+  """Reads and enables pagination through a set of `ProfileTag`."""
+  profileTagsByEntityId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProfileTagCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `ProfileTag`."""
+    orderBy: [ProfileTagsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProfileTagsConnection!
 }
 
 """
@@ -1041,6 +1574,90 @@ Represents an update to a `Profile`. Fields that are set will be updated.
 """
 input ProfilePatch {
   id: UUID
+}
+
+type ProfileTag implements Node {
+  entityId: UUID!
+  entityKind: EntityKinds!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+
+  """Reads a single `Profile` that is related to this `ProfileTag`."""
+  profileByEntityId: Profile
+  tag: String!
+}
+
+"""
+A condition to be used against `ProfileTag` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input ProfileTagCondition {
+  """Checks for equality with the object’s `entityId` field."""
+  entityId: UUID
+
+  """Checks for equality with the object’s `entityKind` field."""
+  entityKind: EntityKinds
+
+  """Checks for equality with the object’s `tag` field."""
+  tag: String
+}
+
+"""An input for mutations affecting `ProfileTag`"""
+input ProfileTagInput {
+  entityId: UUID!
+  entityKind: EntityKinds!
+  tag: String!
+}
+
+"""
+Represents an update to a `ProfileTag`. Fields that are set will be updated.
+"""
+input ProfileTagPatch {
+  entityId: UUID
+  entityKind: EntityKinds
+  tag: String
+}
+
+"""A connection to a list of `ProfileTag` values."""
+type ProfileTagsConnection {
+  """
+  A list of edges which contains the `ProfileTag` and cursor to aid in pagination.
+  """
+  edges: [ProfileTagsEdge]!
+
+  """A list of `ProfileTag` objects."""
+  nodes: [ProfileTag]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `ProfileTag` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `ProfileTag` edge in the connection."""
+type ProfileTagsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `ProfileTag` at the end of the edge."""
+  node: ProfileTag
+}
+
+"""Methods to use when ordering `ProfileTag`."""
+enum ProfileTagsOrderBy {
+  ENTITY_ID_ASC
+  ENTITY_ID_DESC
+  ENTITY_KIND_ASC
+  ENTITY_KIND_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  TAG_ASC
+  TAG_DESC
 }
 
 """A connection to a list of `Profile` values."""
@@ -1080,6 +1697,35 @@ enum ProfilesOrderBy {
 
 """The root query type which gives access points into the data universe."""
 type Query implements Node {
+  """Reads and enables pagination through a set of `LocationTag`."""
+  allLocationTags(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: LocationTagCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `LocationTag`."""
+    orderBy: [LocationTagsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): LocationTagsConnection
+
   """Reads and enables pagination through a set of `Location`."""
   allLocations(
     """Read all values in the set after (below) this cursor."""
@@ -1138,6 +1784,35 @@ type Query implements Node {
     orderBy: [MeasurementsOrderBy!] = [PRIMARY_KEY_ASC]
   ): MeasurementsConnection
 
+  """Reads and enables pagination through a set of `PhotoTag`."""
+  allPhotoTags(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PhotoTagCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `PhotoTag`."""
+    orderBy: [PhotoTagsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PhotoTagsConnection
+
   """Reads and enables pagination through a set of `Photo`."""
   allPhotos(
     """Read all values in the set after (below) this cursor."""
@@ -1167,6 +1842,35 @@ type Query implements Node {
     orderBy: [PhotosOrderBy!] = [PRIMARY_KEY_ASC]
   ): PhotosConnection
 
+  """Reads and enables pagination through a set of `ProfileTag`."""
+  allProfileTags(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ProfileTagCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `ProfileTag`."""
+    orderBy: [ProfileTagsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ProfileTagsConnection
+
   """Reads and enables pagination through a set of `Profile`."""
   allProfiles(
     """Read all values in the set after (below) this cursor."""
@@ -1195,35 +1899,6 @@ type Query implements Node {
     """The method to use when ordering `Profile`."""
     orderBy: [ProfilesOrderBy!] = [PRIMARY_KEY_ASC]
   ): ProfilesConnection
-
-  """Reads and enables pagination through a set of `Tag`."""
-  allTags(
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: TagCondition
-
-    """Only read the first `n` values of the set."""
-    first: Int
-
-    """Only read the last `n` values of the set."""
-    last: Int
-
-    """
-    Skip the first `n` values from our `after` cursor, an alternative to cursor
-    based pagination. May not be used with `last`.
-    """
-    offset: Int
-
-    """The method to use when ordering `Tag`."""
-    orderBy: [TagsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): TagsConnection
 
   """Reads and enables pagination through a set of `User`."""
   allUsers(
@@ -1263,6 +1938,17 @@ type Query implements Node {
   """Get a single `Location`."""
   locationById(id: UUID!): Location
 
+  """Reads a single `LocationTag` using its globally unique `ID`."""
+  locationTag(
+    """
+    The globally unique `ID` to be used in selecting a single `LocationTag`.
+    """
+    nodeId: ID!
+  ): LocationTag
+
+  """Get a single `LocationTag`."""
+  locationTagByEntityKindAndEntityIdAndTag(entityId: UUID!, entityKind: EntityKinds!, tag: String!): LocationTag
+
   """Reads a single `Measurement` using its globally unique `ID`."""
   measurement(
     """
@@ -1294,6 +1980,15 @@ type Query implements Node {
   """Get a single `Photo`."""
   photoById(id: UUID!): Photo
 
+  """Reads a single `PhotoTag` using its globally unique `ID`."""
+  photoTag(
+    """The globally unique `ID` to be used in selecting a single `PhotoTag`."""
+    nodeId: ID!
+  ): PhotoTag
+
+  """Get a single `PhotoTag`."""
+  photoTagByEntityKindAndEntityIdAndTag(entityId: UUID!, entityKind: EntityKinds!, tag: String!): PhotoTag
+
   """Reads a single `Profile` using its globally unique `ID`."""
   profile(
     """The globally unique `ID` to be used in selecting a single `Profile`."""
@@ -1303,20 +1998,22 @@ type Query implements Node {
   """Get a single `Profile`."""
   profileById(id: UUID!): Profile
 
+  """Reads a single `ProfileTag` using its globally unique `ID`."""
+  profileTag(
+    """
+    The globally unique `ID` to be used in selecting a single `ProfileTag`.
+    """
+    nodeId: ID!
+  ): ProfileTag
+
+  """Get a single `ProfileTag`."""
+  profileTagByEntityKindAndEntityIdAndTag(entityId: UUID!, entityKind: EntityKinds!, tag: String!): ProfileTag
+
   """
   Exposes the root query type nested one level down. This is helpful for Relay 1
   which can only query top level fields if they are in a particular form.
   """
   query: Query!
-
-  """Reads a single `Tag` using its globally unique `ID`."""
-  tag(
-    """The globally unique `ID` to be used in selecting a single `Tag`."""
-    nodeId: ID!
-  ): Tag
-
-  """Get a single `Tag`."""
-  tagByEntityKindAndEntityIdAndTag(entityId: UUID!, entityKind: EntityKinds!, tag: String!): Tag
 
   """Reads a single `User` using its globally unique `ID`."""
   user(
@@ -1326,84 +2023,6 @@ type Query implements Node {
 
   """Get a single `User`."""
   userById(id: Int!): User
-}
-
-type Tag implements Node {
-  entityId: UUID!
-  entityKind: EntityKinds!
-
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
-  tag: String!
-}
-
-"""
-A condition to be used against `Tag` object types. All fields are tested for equality and combined with a logical ‘and.’
-"""
-input TagCondition {
-  """Checks for equality with the object’s `entityId` field."""
-  entityId: UUID
-
-  """Checks for equality with the object’s `entityKind` field."""
-  entityKind: EntityKinds
-
-  """Checks for equality with the object’s `tag` field."""
-  tag: String
-}
-
-"""An input for mutations affecting `Tag`"""
-input TagInput {
-  entityId: UUID!
-  entityKind: EntityKinds!
-  tag: String!
-}
-
-"""Represents an update to a `Tag`. Fields that are set will be updated."""
-input TagPatch {
-  entityId: UUID
-  entityKind: EntityKinds
-  tag: String
-}
-
-"""A connection to a list of `Tag` values."""
-type TagsConnection {
-  """
-  A list of edges which contains the `Tag` and cursor to aid in pagination.
-  """
-  edges: [TagsEdge]!
-
-  """A list of `Tag` objects."""
-  nodes: [Tag]!
-
-  """Information to aid in pagination."""
-  pageInfo: PageInfo!
-
-  """The count of *all* `Tag` you could get from the connection."""
-  totalCount: Int!
-}
-
-"""A `Tag` edge in the connection."""
-type TagsEdge {
-  """A cursor for use in pagination."""
-  cursor: Cursor
-
-  """The `Tag` at the end of the edge."""
-  node: Tag
-}
-
-"""Methods to use when ordering `Tag`."""
-enum TagsOrderBy {
-  ENTITY_ID_ASC
-  ENTITY_ID_DESC
-  ENTITY_KIND_ASC
-  ENTITY_KIND_DESC
-  NATURAL
-  PRIMARY_KEY_ASC
-  PRIMARY_KEY_DESC
-  TAG_ASC
-  TAG_DESC
 }
 
 """
@@ -1461,6 +2080,70 @@ type UpdateLocationPayload {
     """The method to use when ordering `Location`."""
     orderBy: [LocationsOrderBy!]! = [PRIMARY_KEY_ASC]
   ): LocationsEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""
+All input for the `updateLocationTagByEntityKindAndEntityIdAndTag` mutation.
+"""
+input UpdateLocationTagByEntityKindAndEntityIdAndTagInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  entityId: UUID!
+  entityKind: EntityKinds!
+
+  """
+  An object where the defined keys will be set on the `LocationTag` being updated.
+  """
+  locationTagPatch: LocationTagPatch!
+  tag: String!
+}
+
+"""All input for the `updateLocationTag` mutation."""
+input UpdateLocationTagInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `LocationTag` being updated.
+  """
+  locationTagPatch: LocationTagPatch!
+
+  """
+  The globally unique `ID` which will identify a single `LocationTag` to be updated.
+  """
+  nodeId: ID!
+}
+
+"""The output of our update `LocationTag` mutation."""
+type UpdateLocationTagPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """Reads a single `Location` that is related to this `LocationTag`."""
+  locationByEntityId: Location
+
+  """The `LocationTag` that was updated by this mutation."""
+  locationTag: LocationTag
+
+  """An edge for our `LocationTag`. May be used by Relay 1."""
+  locationTagEdge(
+    """The method to use when ordering `LocationTag`."""
+    orderBy: [LocationTagsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): LocationTagsEdge
 
   """
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -1586,6 +2269,70 @@ type UpdatePhotoPayload {
   query: Query
 }
 
+"""
+All input for the `updatePhotoTagByEntityKindAndEntityIdAndTag` mutation.
+"""
+input UpdatePhotoTagByEntityKindAndEntityIdAndTagInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  entityId: UUID!
+  entityKind: EntityKinds!
+
+  """
+  An object where the defined keys will be set on the `PhotoTag` being updated.
+  """
+  photoTagPatch: PhotoTagPatch!
+  tag: String!
+}
+
+"""All input for the `updatePhotoTag` mutation."""
+input UpdatePhotoTagInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `PhotoTag` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the `PhotoTag` being updated.
+  """
+  photoTagPatch: PhotoTagPatch!
+}
+
+"""The output of our update `PhotoTag` mutation."""
+type UpdatePhotoTagPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """Reads a single `Photo` that is related to this `PhotoTag`."""
+  photoByEntityId: Photo
+
+  """The `PhotoTag` that was updated by this mutation."""
+  photoTag: PhotoTag
+
+  """An edge for our `PhotoTag`. May be used by Relay 1."""
+  photoTagEdge(
+    """The method to use when ordering `PhotoTag`."""
+    orderBy: [PhotoTagsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): PhotoTagsEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
 """All input for the `updateProfileById` mutation."""
 input UpdateProfileByIdInput {
   """
@@ -1643,8 +2390,10 @@ type UpdateProfilePayload {
   query: Query
 }
 
-"""All input for the `updateTagByEntityKindAndEntityIdAndTag` mutation."""
-input UpdateTagByEntityKindAndEntityIdAndTagInput {
+"""
+All input for the `updateProfileTagByEntityKindAndEntityIdAndTag` mutation.
+"""
+input UpdateProfileTagByEntityKindAndEntityIdAndTagInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -1652,16 +2401,16 @@ input UpdateTagByEntityKindAndEntityIdAndTagInput {
   clientMutationId: String
   entityId: UUID!
   entityKind: EntityKinds!
-  tag: String!
 
   """
-  An object where the defined keys will be set on the `Tag` being updated.
+  An object where the defined keys will be set on the `ProfileTag` being updated.
   """
-  tagPatch: TagPatch!
+  profileTagPatch: ProfileTagPatch!
+  tag: String!
 }
 
-"""All input for the `updateTag` mutation."""
-input UpdateTagInput {
+"""All input for the `updateProfileTag` mutation."""
+input UpdateProfileTagInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -1669,37 +2418,40 @@ input UpdateTagInput {
   clientMutationId: String
 
   """
-  The globally unique `ID` which will identify a single `Tag` to be updated.
+  The globally unique `ID` which will identify a single `ProfileTag` to be updated.
   """
   nodeId: ID!
 
   """
-  An object where the defined keys will be set on the `Tag` being updated.
+  An object where the defined keys will be set on the `ProfileTag` being updated.
   """
-  tagPatch: TagPatch!
+  profileTagPatch: ProfileTagPatch!
 }
 
-"""The output of our update `Tag` mutation."""
-type UpdateTagPayload {
+"""The output of our update `ProfileTag` mutation."""
+type UpdateProfileTagPayload {
   """
   The exact same `clientMutationId` that was provided in the mutation input,
   unchanged and unused. May be used by a client to track mutations.
   """
   clientMutationId: String
 
+  """Reads a single `Profile` that is related to this `ProfileTag`."""
+  profileByEntityId: Profile
+
+  """The `ProfileTag` that was updated by this mutation."""
+  profileTag: ProfileTag
+
+  """An edge for our `ProfileTag`. May be used by Relay 1."""
+  profileTagEdge(
+    """The method to use when ordering `ProfileTag`."""
+    orderBy: [ProfileTagsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): ProfileTagsEdge
+
   """
   Our root query field type. Allows us to run any query from our mutation payload.
   """
   query: Query
-
-  """The `Tag` that was updated by this mutation."""
-  tag: Tag
-
-  """An edge for our `Tag`. May be used by Relay 1."""
-  tagEdge(
-    """The method to use when ordering `Tag`."""
-    orderBy: [TagsOrderBy!]! = [PRIMARY_KEY_ASC]
-  ): TagsEdge
 }
 
 """All input for the `updateUserById` mutation."""

--- a/postgraphile/website/postgraphile/smart-tags.md
+++ b/postgraphile/website/postgraphile/smart-tags.md
@@ -587,6 +587,20 @@ See [Polymorphism](./polymorphism)
 
 See [Polymorphism](./polymorphism)
 
+### @partitionExpose
+
+By default, if you're using table partitioning, PostGraphile will only expose
+the root partitioned table. You may change this globally with the
+`preset.schema.pgDefaultPartitionedTableExpose` option, or on a per-table basis
+using the `@partitionExpose` smart tag:
+
+- `@partitionExpose parent` - only expose the parent (partitioned) table, not
+  the children (partitions)
+- `@partitionExpose child` - only expose the children (partitions), not
+  the parent partitioned table
+- `@partitionExpose both` - expose both the parent (partitioned) table and all
+  of its partitions
+
 ## Deprecated tags
 
 These tags are only available if you're using the V4 preset, and have been replaced by better methods.

--- a/utils/pg-introspection/src/augmentIntrospection.ts
+++ b/utils/pg-introspection/src/augmentIntrospection.ts
@@ -522,5 +522,12 @@ export function augmentIntrospection(
     entity.getSubType = memo(() => getType(entity.rngsubtype));
   });
 
+  introspection.inherits.forEach((entity) => {
+    entity.getParent = () =>
+      introspection.classes.find((child) => child._id === entity.inhparent);
+    entity.getChild = () =>
+      introspection.classes.find((child) => child._id === entity.inhrelid);
+  });
+
   return introspection;
 }

--- a/utils/pg-introspection/src/index.ts
+++ b/utils/pg-introspection/src/index.ts
@@ -222,4 +222,8 @@ declare module "./introspection.js" {
     getType(): PgType | undefined;
     getSubType(): PgType | undefined;
   }
+  interface PgInherits {
+    getParent(): PgClass | undefined;
+    getChild(): PgClass | undefined;
+  }
 }


### PR DESCRIPTION
Enable partitions to be exposed via the `@partitionExpose child` or
`@partitionExpose both` smart tags on the partitioned table. Also adds a global
configuration option for managing the default setting for this (`parent` by
default: only expose the parent partitioned table, not its underlying child
partitions).

Also, for introspection, make it easier to get parent and child from PgInherits
