### PR TITLE
Respect `pgSettingsForIntrospection` for enum tables

### DIFF
--- a/.changeset/calm-enums-introspect.md
+++ b/.changeset/calm-enums-introspect.md
@@ -1,5 +1,6 @@
 ---
 "graphile-build-pg": patch
+"postgraphile": patch
 ---
 
 Apply `pgSettingsForIntrospection` when reading enum table values.

--- a/.changeset/calm-enums-introspect.md
+++ b/.changeset/calm-enums-introspect.md
@@ -1,0 +1,5 @@
+---
+"graphile-build-pg": patch
+---
+
+Apply `pgSettingsForIntrospection` when reading enum table values.

--- a/graphile-build/graphile-build-pg/__tests__/PgEnumTablesPlugin.test.ts
+++ b/graphile-build/graphile-build-pg/__tests__/PgEnumTablesPlugin.test.ts
@@ -1,0 +1,46 @@
+import { withPgClientFromPgService } from "@dataplan/pg";
+import sql from "pg-sql2";
+
+import { PgEnumTablesPlugin } from "../src/plugins/PgEnumTablesPlugin.ts";
+
+jest.mock("@dataplan/pg", () => ({
+  ...jest.requireActual("@dataplan/pg"),
+  withPgClientFromPgService: jest.fn(),
+}));
+
+test("uses the introspection settings to read enum table values", async () => {
+  const pgSettingsForIntrospection = { role: "introspection_role" };
+  const pgService = {
+    name: "main",
+    pgSettingsForIntrospection,
+  };
+  const mockedWithPgClientFromPgService = jest.mocked(
+    withPgClientFromPgService,
+  );
+  mockedWithPgClientFromPgService.mockResolvedValue({ rows: [] });
+
+  const getIntrospectionData =
+    PgEnumTablesPlugin.gather?.helpers?.getIntrospectionData;
+  if (!getIntrospectionData) {
+    throw new Error("PgEnumTablesPlugin.getIntrospectionData is not defined");
+  }
+
+  await getIntrospectionData(
+    {
+      lib: { sql },
+      resolvedPreset: { pgServices: [pgService] },
+    } as never,
+    "main",
+    {
+      getNamespace: () => ({ nspname: "app" }),
+      relname: "status",
+    } as never,
+    [{ attname: "value" }] as never,
+  );
+
+  expect(mockedWithPgClientFromPgService).toHaveBeenCalledWith(
+    pgService,
+    pgSettingsForIntrospection,
+    expect.any(Function),
+  );
+});

--- a/graphile-build/graphile-build-pg/src/plugins/PgEnumTablesPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgEnumTablesPlugin.ts
@@ -199,7 +199,7 @@ export const PgEnumTablesPlugin: GraphileConfig.Plugin = {
         try {
           const { rows } = await withPgClientFromPgService(
             pgService!,
-            null,
+            pgService?.pgSettingsForIntrospection ?? null,
             (client) => client.query<Record<string, string>>(query),
           );
           return rows;
@@ -208,7 +208,7 @@ export const PgEnumTablesPlugin: GraphileConfig.Plugin = {
           try {
             const { rows } = await withPgClientFromPgService(
               pgService!,
-              null,
+              pgService?.pgSettingsForIntrospection ?? null,
               (client) =>
                 client.query<{ user: string }>({
                   text: "select user;",


### PR DESCRIPTION
## Summary

`PgIntrospectionPlugin` applies `pgSettingsForIntrospection` during PostgreSQL
catalog introspection, but `PgEnumTablesPlugin` currently reads enum table values
without those settings.

This causes enum table discovery to run as the connection role rather than the
configured introspection role. It fails when the connection role intentionally
has no direct table access and must switch roles for introspection.

This change:

- applies `pgSettingsForIntrospection` when reading enum table values
- applies the same settings to the diagnostic query after a failed read
- adds a focused regression test
- adds a patch changeset for `graphile-build-pg`

## Testing

- `yarn build`
- `yarn workspace graphile-build-pg build`
- `yarn workspace graphile-build-pg test --runInBand`
- ESLint and Prettier checks for the changed files