### PR TITLE
Fix loadOneWithPgClient/loadManyWithPgClient with promise lists

### DIFF
--- a/.changeset/bright-walls-poke.md
+++ b/.changeset/bright-walls-poke.md
@@ -1,0 +1,8 @@
+---
+"@dataplan/pg": patch
+"postgraphile": patch
+---
+
+Fix bug in `loadOneWithPgClient` and `loadManyWithPgClient` where the PG client
+might be released early if the loader returns a list of promises (or promise to
+the same). Solution is simple: wrap the list with `Promise.all(...)`.

--- a/grafast/dataplan-pg/src/steps/withPgClient.ts
+++ b/grafast/dataplan-pg/src/steps/withPgClient.ts
@@ -251,7 +251,9 @@ function transformLoadOneLoader<
         return pgExecutorContext.withPgClient(
           pgExecutorContext.pgSettings,
           (pgClient) =>
-            Promise.resolve(loaderObject.load(pgClient, lookups, info as any)),
+            Promise.resolve(loaderObject.load(pgClient, lookups, info as any))
+              // It's necessary to await the inner promises, otherwise we might release the client early
+              .then((list) => Promise.all(list)),
         );
       },
     };
@@ -309,7 +311,9 @@ function transformLoadManyLoader<
         return pgExecutorContext.withPgClient(
           pgExecutorContext.pgSettings,
           (pgClient) =>
-            Promise.resolve(loaderObject.load(pgClient, lookups, info as any)),
+            Promise.resolve(loaderObject.load(pgClient, lookups, info as any))
+              // It's necessary to await the inner promises, otherwise we might release the client early
+              .then((list) => Promise.all(list)),
         );
       },
     };


### PR DESCRIPTION
If you `return lookups.map(lookup => ... pgClient.query(...) ...)` (which you shouldn't! do all async logic before you map over the results, batched!) then these utilities would (not so...) helpfully release the pgClient - sometimes before you finish using the client. This could lead to interesting bugs!

To solve this, we now wrap the returned lists with `Promise.all(...)` to ensure they're fully evaluated. It's not ideal (and we may want to optimize this later) but for now it's a simple fix.