### PR TITLE
Add setChildInliningStrategy

### DIFF
--- a/.changeset/ninety-owls-own.md
+++ b/.changeset/ninety-owls-own.md
@@ -4,7 +4,12 @@
 ---
 
 `PgSelectStep` now allows influencing the inlining strategy used to inline one
-query into a parent: `preferLeftJoin`, `preferSubquery`, `auto` or `forbidden`.
+query into a parent with `setInliningStrategy(...)`: `preferLeftJoin`,
+`preferSubquery`, `auto` or `forbidden`. It also allows influencing how child
+queries inline into the current query with `setChildInliningStrategy(...)`; this
+applies when the child uses `auto`, unless set to `forbidden` in which case
+children are not inlined.
+
 The auto behavior (default) is now smarter: rather than always using a left join
 where possible (as before), the system will now aim to have no more than 7 joins
 (to avoid combinatorics pressure in PostgreSQL query planning) and will also not

--- a/.github/styles/config/vocabularies/Graphile/accept.txt
+++ b/.github/styles/config/vocabularies/Graphile/accept.txt
@@ -19,3 +19,6 @@ booleans
 preprocessor
 unformatted
 autofixed
+inline
+inlined
+inlining

--- a/.github/styles/config/vocabularies/Graphile/accept.txt
+++ b/.github/styles/config/vocabularies/Graphile/accept.txt
@@ -22,3 +22,5 @@ autofixed
 inline
 inlined
 inlining
+subquery
+subqueries

--- a/grafast/dataplan-pg/src/examples/exampleSchema.ts
+++ b/grafast/dataplan-pg/src/examples/exampleSchema.ts
@@ -1706,9 +1706,9 @@ export function makeExampleSchema(
               ? step.getListStep()
               : (step as PgSelectStep | PgSelectSingleStep);
           if ("getClassStep" in innerPlan) {
-            innerPlan.getClassStep().setInliningForbidden();
-          } else if ("setInliningForbidden" in innerPlan) {
-            innerPlan.setInliningForbidden();
+            innerPlan.getClassStep().setInliningStrategy("forbidden");
+          } else if ("setInliningStrategy" in innerPlan) {
+            innerPlan.setInliningStrategy("forbidden");
           }
         }
         return step;

--- a/grafast/dataplan-pg/src/steps/pgSelect.ts
+++ b/grafast/dataplan-pg/src/steps/pgSelect.ts
@@ -223,8 +223,8 @@ function assertSensible(step: Step): void {
 export type PgSelectMode = "normal" | "aggregate" | "mutation";
 
 /**
- * The SQL strategy to use when a PgSelectStep is inlined into its
- * parent.
+ * The SQL strategy to use when a PgSelectStep is inlined into its parent, or
+ * when a PgSelectStep's children are inlined into it.
  *
  * - `"auto"` - dealers choice (PostGraphile will decide for you - this is the default)
  * - `"forbidden"` - do not inline
@@ -532,6 +532,9 @@ export class PgSelectStep<
   /** The SQL strategy we'll use when inlining into our parent. */
   private inliningStrategy: PgSelectInliningStrategy = "auto";
 
+  /** The SQL strategy we'll suggest when child PgSelectSteps inline into us. */
+  private childInliningStrategy: PgSelectInliningStrategy = "auto";
+
   /**
    * If true and this becomes a join during optimisation then it should become
    * a lateral join; e.g. in the following query, the left join must be
@@ -627,6 +630,7 @@ export class PgSelectStep<
     // TODO: should `isUnique` only be set if mode matches?
     $clone.isUnique = cloneFrom.isUnique;
     $clone.inliningStrategy = cloneFrom.inliningStrategy;
+    $clone.childInliningStrategy = cloneFrom.childInliningStrategy;
 
     for (const [k, v] of cloneFrom._symbolSubstitutes) {
       $clone._symbolSubstitutes.set(k, v);
@@ -805,6 +809,17 @@ export class PgSelectStep<
 
   public getInliningStrategy(): PgSelectInliningStrategy {
     return this.inliningStrategy;
+  }
+
+  public setChildInliningStrategy(
+    newChildInliningStrategy: PgSelectInliningStrategy,
+  ): this {
+    this.childInliningStrategy = newChildInliningStrategy;
+    return this;
+  }
+
+  public getChildInliningStrategy(): PgSelectInliningStrategy {
+    return this.childInliningStrategy;
   }
 
   public setTrusted(newIsTrusted = true): this {
@@ -1445,6 +1460,9 @@ export class PgSelectStep<
       if (p.inliningStrategy !== this.inliningStrategy) {
         return false;
       }
+      if (p.childInliningStrategy !== this.childInliningStrategy) {
+        return false;
+      }
 
       // Check FROM
       if (!sqlIsEquivalent(p.from, this.from)) {
@@ -1873,15 +1891,23 @@ export class PgSelectStep<
       !mightHaveStream &&
       !this.joins.some((j) => j.type !== "left") &&
       (parentDetails = this.getParentForInlining()) !== null &&
+      parentDetails.$pgSelect.childInliningStrategy !== "forbidden" &&
       parentDetails.$pgSelect.mode === "normal"
     ) {
+      // If we're auto mode, use parent's strategy, otherwise our strategy
+      // wins. Never forbidden (already asserted above).
+      const resolvedInliningStrategy =
+        this.inliningStrategy === "auto"
+          ? parentDetails.$pgSelect.childInliningStrategy
+          : this.inliningStrategy;
+
       const { $pgSelect, $pgSelectSingle } = parentDetails;
       const staticInfo = PgSelectStep.getStaticInfo(this);
       const { isSimpleUnique } = staticInfo;
       if (
         isSimpleUnique === true &&
-        (this.inliningStrategy === "preferLeftJoin" ||
-          (this.inliningStrategy === "auto" &&
+        (resolvedInliningStrategy === "preferLeftJoin" ||
+          (resolvedInliningStrategy === "auto" &&
             this.joins.length + this.applyDepIds.length === 0 &&
             $pgSelect.joins.length + $pgSelect.applyDepIds.length <
               AUTO_MAX_INLINE_LEFT_JOINS))

--- a/grafast/website/grafast/step-library/dataplan-pg/pgSelect.md
+++ b/grafast/website/grafast/step-library/dataplan-pg/pgSelect.md
@@ -320,7 +320,7 @@ performance issues. Supported strategies:
 - `auto`: uses heuristics to choose the inlining strategy.
 - `forbidden`: prevents this query from being inlined into its parent.
 - `preferLeftJoin`: prefers the use of a `left join` when this query can return
-  at most one row for each parent row, falling back to a subquery when that is
+  at most one row for each parent row, falling back to a subquery when that's
   not suitable.
 - `preferSubquery`: prefers the use of a subquery in the parent query's `select`
   list.

--- a/grafast/website/grafast/step-library/dataplan-pg/pgSelect.md
+++ b/grafast/website/grafast/step-library/dataplan-pg/pgSelect.md
@@ -312,11 +312,25 @@ Call this ONLY if there can be at most one matching row. If you set this true
 when this is not the case then you may get unexpected results during inlining;
 if in doubt leave it at the default.
 
-### $pgSelect.setInliningForbidden()
+### $pgSelect.setInliningStrategy()
 
-Call this if you wish to prevent this query from being inlined into its parent.
-You may want to do this to work around a performance issue, or to improve the
-cacheability of the step.
+Influences how this query should be inlined into its parent to help address
+performance issues. Supported strategies:
+
+- `auto`: uses heuristics to choose the inlining strategy.
+- `forbidden`: prevents this query from being inlined into its parent.
+- `preferLeftJoin`: prefers the use of a `left join` when this query can return
+  at most one row for each parent row, falling back to a subquery when that is
+  not suitable.
+- `preferSubquery`: prefers the use of a subquery in the parent query's `select`
+  list.
+
+### $pgSelect.setChildInliningStrategy()
+
+Influences how child queries using the `auto` strategy should be inlined into
+this query. Setting this to `forbidden` prevents children from being inlined.
+Child queries with an explicit `preferLeftJoin` or `preferSubquery` strategy
+override this setting.
 
 ### $pgSelect.setTrusted()
 

--- a/postgraphile/website/postgraphile/grafast-for-postgraphile-users.md
+++ b/postgraphile/website/postgraphile/grafast-for-postgraphile-users.md
@@ -112,7 +112,10 @@ A `pgSelect` step has loads of useful methods, including:
   have the same values for the ordered columns) set this for efficiency
 - `.groupBy(...)` - add a `GROUP BY` clause
 - `.having(...)` - add a `HAVING` clause
-- `.setInliningForbidden()` - prevent this select being inlined into its parent
+- `.setInliningStrategy()` - choose if/how the step should be inlined into the
+  parent
+- `.setChildInliningStrategy()` - choose if/how child steps should be inlined
+  into this step
 - `.setTrusted()` - don't invoke the `selectAuth()` and other methods from the
   resource (for efficiency, presumably because they were already validated some other way).
 - `.setUnique()` - indicate that this will return at most one row.


### PR DESCRIPTION
As with #3146, but this allows a step to influence if or how its children are inlined into it. If you want a query to be truly standalone you can do:

```ts
$pgSelect.setInliningStrategy("forbidden"); // Prevent this query being inlined into a parent
$pgSelect.setChildInliningStrategy("forbidden"); // Prevent any children being inlined into this query
```