### PR TITLE
Use materialized CTE for lateral joins

### DIFF
--- a/.changeset/bumpy-teams-learn.md
+++ b/.changeset/bumpy-teams-learn.md
@@ -1,0 +1,9 @@
+---
+"postgraphile": minor
+"@dataplan/pg": minor
+---
+
+Switch `PgSelectStep` and `PgUnionStep` from a subquery lateral join to a
+**materialized** CTE lateral join. This appears to fix some bad planning
+decisions that Postgres can make, e.g. where it might attempt a full table scan
+hash join rather than a fast loop with efficient index lookups.

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-1.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-1.deopt.sql
@@ -24,8 +24,11 @@ where
   )
 order by __messages__."id" asc;
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-2.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-2.deopt.sql
@@ -24,8 +24,11 @@ where
   )
 order by __messages__."id" asc;
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-2.sql
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-2.sql
@@ -24,8 +24,11 @@ where
   )
 order by __forums__."id" asc;
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-3.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-3.deopt.sql
@@ -24,8 +24,11 @@ where
   )
 order by __messages__."id" asc;
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-3.sql
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-3.sql
@@ -24,8 +24,11 @@ where
   )
 order by __forums__."id" asc;
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-4.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-4.deopt.sql
@@ -34,8 +34,11 @@ where
     (__messages__.archived_at is null) = ($2::"timestamptz" is null)
   );
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-4.sql
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-4.sql
@@ -47,8 +47,11 @@ where
   )
 order by __forums__."id" asc;
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-5.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-5.deopt.sql
@@ -34,8 +34,11 @@ where
     (__messages__.archived_at is null) = ($2::"timestamptz" is null)
   );
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-6.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-6.deopt.sql
@@ -24,8 +24,11 @@ where
   )
 order by __messages__."id" asc;
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-6.sql
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-6.sql
@@ -24,8 +24,11 @@ where
   )
 order by __forums__."id" asc;
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-7.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-7.deopt.sql
@@ -24,8 +24,11 @@ where
   )
 order by __messages__."id" asc;
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-7.sql
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-7.sql
@@ -24,8 +24,11 @@ where
   )
 order by __messages__."id" asc;
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.deopt.sql
@@ -34,8 +34,11 @@ where
     (__messages__.archived_at is null) = ($2::"timestamptz" is null)
   );
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-1.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-1.deopt.sql
@@ -32,8 +32,11 @@ close __SNAPSHOT_CURSOR_0__
 
 commit; /*fake*/
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-1.sql
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-1.sql
@@ -32,8 +32,11 @@ close __SNAPSHOT_CURSOR_0__
 
 commit; /*fake*/
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-2.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-2.deopt.sql
@@ -43,8 +43,11 @@ where
     (__messages__.archived_at is null) = ($2::"timestamptz" is null)
   );
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-2.sql
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-2.sql
@@ -45,8 +45,11 @@ close __SNAPSHOT_CURSOR_0__
 
 commit; /*fake*/
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-3.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-3.deopt.sql
@@ -71,8 +71,11 @@ where
     true /* authorization checks */
   );
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-3.sql
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-3.sql
@@ -71,8 +71,11 @@ where
     true /* authorization checks */
   );
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-4.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-4.deopt.sql
@@ -60,8 +60,11 @@ close __SNAPSHOT_CURSOR_0__
 
 commit; /*fake*/
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-4.sql
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-4.sql
@@ -60,8 +60,11 @@ close __SNAPSHOT_CURSOR_0__
 
 commit; /*fake*/
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-6.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-6.deopt.sql
@@ -43,8 +43,11 @@ where
     (__messages__.archived_at is null) = ($2::"timestamptz" is null)
   );
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-6.sql
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-6.sql
@@ -43,8 +43,11 @@ where
     (__messages__.archived_at is null) = ($2::"timestamptz" is null)
   );
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-7.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-7.deopt.sql
@@ -24,8 +24,11 @@ where
   )
 order by __messages__."id" asc;
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",
@@ -49,8 +52,11 @@ where
     (__messages__.archived_at is null) = ($2::"timestamptz" is null)
   );
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-7.sql
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-7.sql
@@ -46,8 +46,11 @@ where
     (__messages__.archived_at is null) = ($2::"timestamptz" is null)
   );
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/conditions/basics-with-author.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/basics-with-author.deopt.sql
@@ -8,8 +8,11 @@ where (
 )
 order by __forums__."id" asc;
 
+with __messages_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0", (ids.value->>1)::"timestamptz" as "id1" from json_array_elements($1::json) with ordinality as ids
+)
 select __messages_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0", (ids.value->>1)::"timestamptz" as "id1" from json_array_elements($1::json) with ordinality as ids) as __messages_identifiers__,
+from __messages_identifiers__,
 lateral (
   select
     __messages__."body" as "0",
@@ -26,8 +29,11 @@ lateral (
   limit 2
 ) as __messages_result__;
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/conditions/basics.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/basics.deopt.sql
@@ -8,8 +8,11 @@ where (
 )
 order by __forums__."id" asc;
 
+with __messages_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0", (ids.value->>1)::"timestamptz" as "id1" from json_array_elements($1::json) with ordinality as ids
+)
 select __messages_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0", (ids.value->>1)::"timestamptz" as "id1" from json_array_elements($1::json) with ordinality as ids) as __messages_identifiers__,
+from __messages_identifiers__,
 lateral (
   select
     __messages__."body" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/conditions/condition-featured-messages-minimal.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/condition-featured-messages-minimal.deopt.sql
@@ -10,8 +10,11 @@ where
   )
 order by __forums__."id" asc;
 
+with __messages_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0", (ids.value->>1)::"timestamptz" as "id1" from json_array_elements($2::json) with ordinality as ids
+)
 select __messages_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0", (ids.value->>1)::"timestamptz" as "id1" from json_array_elements($2::json) with ordinality as ids) as __messages_identifiers__,
+from __messages_identifiers__,
 lateral (
   select
     __messages_identifiers__.idx as "0"
@@ -28,8 +31,11 @@ lateral (
   limit 6
 ) as __messages_result__;
 
+with __messages_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0", (ids.value->>1)::"timestamptz" as "id1" from json_array_elements($2::json) with ordinality as ids
+)
 select __messages_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0", (ids.value->>1)::"timestamptz" as "id1" from json_array_elements($2::json) with ordinality as ids) as __messages_identifiers__,
+from __messages_identifiers__,
 lateral (
   select
     (count(*))::text as "0",

--- a/grafast/dataplan-pg/__tests__/queries/conditions/condition-featured-messages.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/condition-featured-messages.deopt.sql
@@ -11,8 +11,11 @@ where
   )
 order by __forums__."id" asc;
 
+with __messages_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0", (ids.value->>1)::"timestamptz" as "id1" from json_array_elements($2::json) with ordinality as ids
+)
 select __messages_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0", (ids.value->>1)::"timestamptz" as "id1" from json_array_elements($2::json) with ordinality as ids) as __messages_identifiers__,
+from __messages_identifiers__,
 lateral (
   select
     __messages__."body" as "0",
@@ -32,8 +35,11 @@ lateral (
   limit 6
 ) as __messages_result__;
 
+with __messages_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0", (ids.value->>1)::"timestamptz" as "id1" from json_array_elements($2::json) with ordinality as ids
+)
 select __messages_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0", (ids.value->>1)::"timestamptz" as "id1" from json_array_elements($2::json) with ordinality as ids) as __messages_identifiers__,
+from __messages_identifiers__,
 lateral (
   select
     (count(*))::text as "0",

--- a/grafast/dataplan-pg/__tests__/queries/conditions/exclusively-archived-messages.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/exclusively-archived-messages.deopt.sql
@@ -8,8 +8,11 @@ where (
 )
 order by __forums__."id" asc;
 
+with __messages_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0", (ids.value->>1)::"timestamptz" as "id1" from json_array_elements($1::json) with ordinality as ids
+)
 select __messages_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0", (ids.value->>1)::"timestamptz" as "id1" from json_array_elements($1::json) with ordinality as ids) as __messages_identifiers__,
+from __messages_identifiers__,
 lateral (
   select
     __messages__."body" as "0",
@@ -27,8 +30,11 @@ lateral (
   limit 6
 ) as __messages_result__;
 
+with __messages_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0", (ids.value->>1)::"timestamptz" as "id1" from json_array_elements($1::json) with ordinality as ids
+)
 select __messages_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0", (ids.value->>1)::"timestamptz" as "id1" from json_array_elements($1::json) with ordinality as ids) as __messages_identifiers__,
+from __messages_identifiers__,
 lateral (
   select
     (count(*))::text as "0",
@@ -42,8 +48,11 @@ lateral (
     )
 ) as __messages_result__;
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/conditions/include-all-archived.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/include-all-archived.deopt.sql
@@ -9,8 +9,11 @@ where (
 order by __forums__."id" asc
 limit 2;
 
+with __messages_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0", (ids.value->>1)::"timestamptz" as "id1" from json_array_elements($1::json) with ordinality as ids
+)
 select __messages_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0", (ids.value->>1)::"timestamptz" as "id1" from json_array_elements($1::json) with ordinality as ids) as __messages_identifiers__,
+from __messages_identifiers__,
 lateral (
   select
     __messages__."body" as "0",
@@ -24,8 +27,11 @@ lateral (
   limit 2
 ) as __messages_result__;
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/connections/basics-limit3.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/connections/basics-limit3.deopt.sql
@@ -22,8 +22,11 @@ where
     __messages__.archived_at is null
   );
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/connections/basics.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/connections/basics.deopt.sql
@@ -21,8 +21,11 @@ where
     __messages__.archived_at is null
   );
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/connections/empty.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/connections/empty.deopt.sql
@@ -11,8 +11,11 @@ where
   )
 order by __forums__."id" asc;
 
+with __messages_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0", (ids.value->>1)::"timestamptz" as "id1" from json_array_elements($1::json) with ordinality as ids
+)
 select __messages_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0", (ids.value->>1)::"timestamptz" as "id1" from json_array_elements($1::json) with ordinality as ids) as __messages_identifiers__,
+from __messages_identifiers__,
 lateral (
   select
     __messages_identifiers__.idx as "0"

--- a/grafast/dataplan-pg/__tests__/queries/connections/order.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/connections/order.deopt.sql
@@ -28,8 +28,11 @@ where
     __messages__.archived_at is null
   );
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/connections/order.variables.array.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/connections/order.variables.array.deopt.sql
@@ -28,8 +28,11 @@ where
     __messages__.archived_at is null
   );
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/connections/order.variables.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/connections/order.variables.deopt.sql
@@ -28,8 +28,11 @@ where
     __messages__.archived_at is null
   );
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/connections/order.variables.multiple.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/connections/order.variables.multiple.deopt.sql
@@ -28,8 +28,11 @@ where
     __messages__.archived_at is null
   );
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/connections/order.variables.string.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/connections/order.variables.string.deopt.sql
@@ -28,8 +28,11 @@ where
     __messages__.archived_at is null
   );
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/connections/order.variables.strings.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/connections/order.variables.strings.deopt.sql
@@ -28,8 +28,11 @@ where
     __messages__.archived_at is null
   );
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-after.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-after.deopt.sql
@@ -24,8 +24,11 @@ where
     __messages__.archived_at is null
   );
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-end-last.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-end-last.deopt.sql
@@ -24,8 +24,11 @@ where
     __messages__.archived_at is null
   );
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-end-last.variables.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-end-last.variables.deopt.sql
@@ -24,8 +24,11 @@ where
     __messages__.archived_at is null
   );
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-end.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-end.deopt.sql
@@ -24,8 +24,11 @@ where
     __messages__.archived_at is null
   );
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-end.variables.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-end.variables.deopt.sql
@@ -24,8 +24,11 @@ where
     __messages__.archived_at is null
   );
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-last.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-last.deopt.sql
@@ -24,8 +24,11 @@ where
     __messages__.archived_at is null
   );
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-last.variables.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-last.variables.deopt.sql
@@ -24,8 +24,11 @@ where
     __messages__.archived_at is null
   );
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before.deopt.sql
@@ -24,8 +24,11 @@ where
     __messages__.archived_at is null
   );
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before.variables.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before.variables.deopt.sql
@@ -24,8 +24,11 @@ where
     __messages__.archived_at is null
   );
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-when-inlined-backwards-nodes-only.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-when-inlined-backwards-nodes-only.deopt.sql
@@ -9,8 +9,11 @@ where (
 order by __forums__."id" asc
 limit 2;
 
+with __messages_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0", (ids.value->>1)::"timestamptz" as "id1" from json_array_elements($1::json) with ordinality as ids
+)
 select __messages_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0", (ids.value->>1)::"timestamptz" as "id1" from json_array_elements($1::json) with ordinality as ids) as __messages_identifiers__,
+from __messages_identifiers__,
 lateral (
   select
     __messages__."body" as "0",
@@ -28,8 +31,11 @@ lateral (
   limit 3
 ) as __messages_result__;
 
+with __messages_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0", (ids.value->>1)::"timestamptz" as "id1" from json_array_elements($1::json) with ordinality as ids
+)
 select __messages_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0", (ids.value->>1)::"timestamptz" as "id1" from json_array_elements($1::json) with ordinality as ids) as __messages_identifiers__,
+from __messages_identifiers__,
 lateral (
   select
     (count(*))::text as "0",
@@ -43,8 +49,11 @@ lateral (
     )
 ) as __messages_result__;
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-when-inlined-backwards.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-when-inlined-backwards.deopt.sql
@@ -9,8 +9,11 @@ where (
 order by __forums__."id" asc
 limit 2;
 
+with __messages_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0", (ids.value->>1)::"timestamptz" as "id1" from json_array_elements($1::json) with ordinality as ids
+)
 select __messages_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0", (ids.value->>1)::"timestamptz" as "id1" from json_array_elements($1::json) with ordinality as ids) as __messages_identifiers__,
+from __messages_identifiers__,
 lateral (
   select
     __messages__."body" as "0",
@@ -28,8 +31,11 @@ lateral (
   limit 3
 ) as __messages_result__;
 
+with __messages_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0", (ids.value->>1)::"timestamptz" as "id1" from json_array_elements($1::json) with ordinality as ids
+)
 select __messages_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0", (ids.value->>1)::"timestamptz" as "id1" from json_array_elements($1::json) with ordinality as ids) as __messages_identifiers__,
+from __messages_identifiers__,
 lateral (
   select
     (count(*))::text as "0",
@@ -43,8 +49,11 @@ lateral (
     )
 ) as __messages_result__;
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-when-inlined.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-when-inlined.deopt.sql
@@ -9,8 +9,11 @@ where (
 order by __forums__."id" asc
 limit 2;
 
+with __messages_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0", (ids.value->>1)::"timestamptz" as "id1" from json_array_elements($1::json) with ordinality as ids
+)
 select __messages_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0", (ids.value->>1)::"timestamptz" as "id1" from json_array_elements($1::json) with ordinality as ids) as __messages_identifiers__,
+from __messages_identifiers__,
 lateral (
   select
     __messages__."body" as "0",
@@ -28,8 +31,11 @@ lateral (
   limit 3
 ) as __messages_result__;
 
+with __messages_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0", (ids.value->>1)::"timestamptz" as "id1" from json_array_elements($1::json) with ordinality as ids
+)
 select __messages_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0", (ids.value->>1)::"timestamptz" as "id1" from json_array_elements($1::json) with ordinality as ids) as __messages_identifiers__,
+from __messages_identifiers__,
 lateral (
   select
     (count(*))::text as "0",
@@ -43,8 +49,11 @@ lateral (
     )
 ) as __messages_result__;
 
+with __users_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __users_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __users_identifiers__,
+from __users_identifiers__,
 lateral (
   select
     __users__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/functions/computed-column-forums-messages-list-set.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/functions/computed-column-forums-messages-list-set.deopt.sql
@@ -14,8 +14,11 @@ where
   )
 order by __forums__."id" asc;
 
+with __forums_messages_list_set_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::app_public.forums as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __forums_messages_list_set_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::app_public.forums as "id0" from json_array_elements($1::json) with ordinality as ids) as __forums_messages_list_set_identifiers__,
+from __forums_messages_list_set_identifiers__,
 lateral (
   select
     __forums_messages_list_set__."body" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/basics-with-fragments.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/basics-with-fragments.deopt.sql
@@ -7,8 +7,11 @@ where (
 )
 order by __people__."person_id" asc;
 
+with __relational_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_items_identifiers__,
+from __relational_items_identifiers__,
 lateral (
   select
     __relational_items__."id"::text as "0",
@@ -30,8 +33,11 @@ lateral (
   order by __relational_items__."id" asc
 ) as __relational_items_result__;
 
+with __relational_topics_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_topics_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_topics_identifiers__,
+from __relational_topics_identifiers__,
 lateral (
   select
     __relational_topics__."title" as "0",
@@ -46,8 +52,11 @@ lateral (
     )
 ) as __relational_topics_result__;
 
+with __relational_posts_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_posts_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_posts_identifiers__,
+from __relational_posts_identifiers__,
 lateral (
   select
     __relational_posts__."title" as "0",
@@ -64,8 +73,11 @@ lateral (
     )
 ) as __relational_posts_result__;
 
+with __relational_dividers_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_dividers_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_dividers_identifiers__,
+from __relational_dividers_identifiers__,
 lateral (
   select
     __relational_dividers__."title" as "0",
@@ -92,8 +104,11 @@ where
     true /* authorization checks */
   );
 
+with __relational_checklist_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_checklist_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_checklist_items_identifiers__,
+from __relational_checklist_items_identifiers__,
 lateral (
   select
     __relational_checklist_items__."description" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/basics-with-fragments.sql
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/basics-with-fragments.sql
@@ -26,8 +26,11 @@ where (
 )
 order by __people__."person_id" asc;
 
+with __relational_topics_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_topics_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_topics_identifiers__,
+from __relational_topics_identifiers__,
 lateral (
   select
     __relational_topics__."title" as "0",
@@ -42,8 +45,11 @@ lateral (
     )
 ) as __relational_topics_result__;
 
+with __relational_posts_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_posts_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_posts_identifiers__,
+from __relational_posts_identifiers__,
 lateral (
   select
     __relational_posts__."title" as "0",
@@ -60,8 +66,11 @@ lateral (
     )
 ) as __relational_posts_result__;
 
+with __relational_dividers_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_dividers_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_dividers_identifiers__,
+from __relational_dividers_identifiers__,
 lateral (
   select
     __relational_dividers__."title" as "0",
@@ -88,8 +97,11 @@ where
     true /* authorization checks */
   );
 
+with __relational_checklist_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_checklist_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_checklist_items_identifiers__,
+from __relational_checklist_items_identifiers__,
 lateral (
   select
     __relational_checklist_items__."description" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/basics.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/basics.deopt.sql
@@ -7,8 +7,11 @@ where (
 )
 order by __people__."person_id" asc;
 
+with __relational_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_items_identifiers__,
+from __relational_items_identifiers__,
 lateral (
   select
     __relational_items__."id"::text as "0",
@@ -30,8 +33,11 @@ lateral (
   order by __relational_items__."id" asc
 ) as __relational_items_result__;
 
+with __relational_topics_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_topics_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_topics_identifiers__,
+from __relational_topics_identifiers__,
 lateral (
   select
     __relational_topics__."id"::text as "0",
@@ -45,8 +51,11 @@ lateral (
     )
 ) as __relational_topics_result__;
 
+with __relational_posts_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_posts_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_posts_identifiers__,
+from __relational_posts_identifiers__,
 lateral (
   select
     __relational_posts__."id"::text as "0",
@@ -60,8 +69,11 @@ lateral (
     )
 ) as __relational_posts_result__;
 
+with __relational_dividers_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_dividers_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_dividers_identifiers__,
+from __relational_dividers_identifiers__,
 lateral (
   select
     __relational_dividers__."id"::text as "0",
@@ -85,8 +97,11 @@ where
     true /* authorization checks */
   );
 
+with __relational_checklist_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_checklist_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_checklist_items_identifiers__,
+from __relational_checklist_items_identifiers__,
 lateral (
   select
     __relational_checklist_items__."id"::text as "0",

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/basics.sql
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/basics.sql
@@ -26,8 +26,11 @@ where (
 )
 order by __people__."person_id" asc;
 
+with __relational_topics_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_topics_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_topics_identifiers__,
+from __relational_topics_identifiers__,
 lateral (
   select
     __relational_topics__."id"::text as "0",
@@ -41,8 +44,11 @@ lateral (
     )
 ) as __relational_topics_result__;
 
+with __relational_posts_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_posts_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_posts_identifiers__,
+from __relational_posts_identifiers__,
 lateral (
   select
     __relational_posts__."id"::text as "0",
@@ -56,8 +62,11 @@ lateral (
     )
 ) as __relational_posts_result__;
 
+with __relational_dividers_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_dividers_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_dividers_identifiers__,
+from __relational_dividers_identifiers__,
 lateral (
   select
     __relational_dividers__."id"::text as "0",
@@ -81,8 +90,11 @@ where
     true /* authorization checks */
   );
 
+with __relational_checklist_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_checklist_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_checklist_items_identifiers__,
+from __relational_checklist_items_identifiers__,
 lateral (
   select
     __relational_checklist_items__."id"::text as "0",

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/commentables.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/commentables.deopt.sql
@@ -7,8 +7,11 @@ where (
 )
 order by __relational_commentables__.id asc;
 
+with __relational_posts_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_posts_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_posts_identifiers__,
+from __relational_posts_identifiers__,
 lateral (
   select
     __relational_posts__."id"::text as "0",
@@ -60,8 +63,11 @@ where
     true /* authorization checks */
   );
 
+with __relational_checklist_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_checklist_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_checklist_items_identifiers__,
+from __relational_checklist_items_identifiers__,
 lateral (
   select
     __relational_checklist_items__."id"::text as "0",

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/commentables.sql
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/commentables.sql
@@ -7,8 +7,11 @@ where (
 )
 order by __relational_commentables__.id asc;
 
+with __relational_posts_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_posts_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_posts_identifiers__,
+from __relational_posts_identifiers__,
 lateral (
   select
     __relational_posts__."id"::text as "0",
@@ -60,8 +63,11 @@ where
     true /* authorization checks */
   );
 
+with __relational_checklist_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_checklist_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_checklist_items_identifiers__,
+from __relational_checklist_items_identifiers__,
 lateral (
   select
     __relational_checklist_items__."id"::text as "0",

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested-more-fragments.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested-more-fragments.deopt.sql
@@ -7,8 +7,11 @@ where (
 )
 order by __people__."person_id" asc;
 
+with __relational_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_items_identifiers__,
+from __relational_items_identifiers__,
 lateral (
   select
     __relational_items__."id"::text as "0",
@@ -32,8 +35,11 @@ lateral (
   order by __relational_items__."id" asc
 ) as __relational_items_result__;
 
+with __people_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __people_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __people_identifiers__,
+from __people_identifiers__,
 lateral (
   select
     __people__."username" as "0",
@@ -47,8 +53,11 @@ lateral (
     )
 ) as __people_result__;
 
+with __relational_topics_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_topics_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_topics_identifiers__,
+from __relational_topics_identifiers__,
 lateral (
   select
     __relational_topics__."title" as "0",
@@ -63,8 +72,11 @@ lateral (
     )
 ) as __relational_topics_result__;
 
+with __relational_posts_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_posts_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_posts_identifiers__,
+from __relational_posts_identifiers__,
 lateral (
   select
     __relational_posts__."title" as "0",
@@ -81,8 +93,11 @@ lateral (
     )
 ) as __relational_posts_result__;
 
+with __relational_dividers_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_dividers_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_dividers_identifiers__,
+from __relational_dividers_identifiers__,
 lateral (
   select
     __relational_dividers__."title" as "0",
@@ -109,8 +124,11 @@ where
     true /* authorization checks */
   );
 
+with __relational_checklist_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_checklist_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_checklist_items_identifiers__,
+from __relational_checklist_items_identifiers__,
 lateral (
   select
     __relational_checklist_items__."description" as "0",
@@ -125,8 +143,11 @@ lateral (
     )
 ) as __relational_checklist_items_result__;
 
+with __relational_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_items_identifiers__,
+from __relational_items_identifiers__,
 lateral (
   select
     __relational_items__."id"::text as "0",
@@ -148,8 +169,11 @@ lateral (
     )
 ) as __relational_items_result__;
 
+with __people_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __people_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __people_identifiers__,
+from __people_identifiers__,
 lateral (
   select
     __people__."username" as "0",
@@ -176,8 +200,11 @@ where
     true /* authorization checks */
   );
 
+with __relational_checklists_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_checklists_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_checklists_identifiers__,
+from __relational_checklists_identifiers__,
 lateral (
   select
     __relational_checklists__."title" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested-more-fragments.sql
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested-more-fragments.sql
@@ -65,8 +65,11 @@ where (
 )
 order by __people_3."person_id" asc;
 
+with __relational_topics_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_topics_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_topics_identifiers__,
+from __relational_topics_identifiers__,
 lateral (
   select
     __relational_topics__."title" as "0",
@@ -81,8 +84,11 @@ lateral (
     )
 ) as __relational_topics_result__;
 
+with __relational_posts_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_posts_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_posts_identifiers__,
+from __relational_posts_identifiers__,
 lateral (
   select
     __relational_posts__."title" as "0",
@@ -99,8 +105,11 @@ lateral (
     )
 ) as __relational_posts_result__;
 
+with __relational_dividers_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_dividers_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_dividers_identifiers__,
+from __relational_dividers_identifiers__,
 lateral (
   select
     __relational_dividers__."title" as "0",
@@ -127,8 +136,11 @@ where
     true /* authorization checks */
   );
 
+with __relational_checklist_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_checklist_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_checklist_items_identifiers__,
+from __relational_checklist_items_identifiers__,
 lateral (
   select
     __relational_checklist_items__."description" as "0",
@@ -156,8 +168,11 @@ where
     true /* authorization checks */
   );
 
+with __relational_checklists_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_checklists_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_checklists_identifiers__,
+from __relational_checklists_identifiers__,
 lateral (
   select
     __relational_checklists__."title" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested-more.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested-more.deopt.sql
@@ -7,8 +7,11 @@ where (
 )
 order by __people__."person_id" asc;
 
+with __relational_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_items_identifiers__,
+from __relational_items_identifiers__,
 lateral (
   select
     __relational_items__."id"::text as "0",
@@ -32,8 +35,11 @@ lateral (
   order by __relational_items__."id" asc
 ) as __relational_items_result__;
 
+with __people_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __people_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __people_identifiers__,
+from __people_identifiers__,
 lateral (
   select
     __people__."username" as "0",
@@ -47,8 +53,11 @@ lateral (
     )
 ) as __people_result__;
 
+with __relational_topics_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_topics_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_topics_identifiers__,
+from __relational_topics_identifiers__,
 lateral (
   select
     __relational_topics__."id"::text as "0",
@@ -62,8 +71,11 @@ lateral (
     )
 ) as __relational_topics_result__;
 
+with __relational_posts_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_posts_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_posts_identifiers__,
+from __relational_posts_identifiers__,
 lateral (
   select
     __relational_posts__."id"::text as "0",
@@ -77,8 +89,11 @@ lateral (
     )
 ) as __relational_posts_result__;
 
+with __relational_dividers_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_dividers_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_dividers_identifiers__,
+from __relational_dividers_identifiers__,
 lateral (
   select
     __relational_dividers__."id"::text as "0",
@@ -102,8 +117,11 @@ where
     true /* authorization checks */
   );
 
+with __relational_checklist_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_checklist_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_checklist_items_identifiers__,
+from __relational_checklist_items_identifiers__,
 lateral (
   select
     __relational_checklist_items__."id"::text as "0",
@@ -117,8 +135,11 @@ lateral (
     )
 ) as __relational_checklist_items_result__;
 
+with __relational_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_items_identifiers__,
+from __relational_items_identifiers__,
 lateral (
   select
     __relational_items__."id"::text as "0",
@@ -140,8 +161,11 @@ lateral (
     )
 ) as __relational_items_result__;
 
+with __people_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __people_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __people_identifiers__,
+from __people_identifiers__,
 lateral (
   select
     __people__."username" as "0",
@@ -165,8 +189,11 @@ where
     true /* authorization checks */
   );
 
+with __relational_checklists_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_checklists_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_checklists_identifiers__,
+from __relational_checklists_identifiers__,
 lateral (
   select
     __relational_checklists__."id"::text as "0",

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested-more.sql
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested-more.sql
@@ -65,8 +65,11 @@ where (
 )
 order by __people_3."person_id" asc;
 
+with __relational_topics_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_topics_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_topics_identifiers__,
+from __relational_topics_identifiers__,
 lateral (
   select
     __relational_topics__."id"::text as "0",
@@ -80,8 +83,11 @@ lateral (
     )
 ) as __relational_topics_result__;
 
+with __relational_posts_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_posts_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_posts_identifiers__,
+from __relational_posts_identifiers__,
 lateral (
   select
     __relational_posts__."id"::text as "0",
@@ -95,8 +101,11 @@ lateral (
     )
 ) as __relational_posts_result__;
 
+with __relational_dividers_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_dividers_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_dividers_identifiers__,
+from __relational_dividers_identifiers__,
 lateral (
   select
     __relational_dividers__."id"::text as "0",
@@ -120,8 +129,11 @@ where
     true /* authorization checks */
   );
 
+with __relational_checklist_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_checklist_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_checklist_items_identifiers__,
+from __relational_checklist_items_identifiers__,
 lateral (
   select
     __relational_checklist_items__."id"::text as "0",
@@ -145,8 +157,11 @@ where
     true /* authorization checks */
   );
 
+with __relational_checklists_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_checklists_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_checklists_identifiers__,
+from __relational_checklists_identifiers__,
 lateral (
   select
     __relational_checklists__."id"::text as "0",

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested.deopt.sql
@@ -7,8 +7,11 @@ where (
 )
 order by __people__."person_id" asc;
 
+with __relational_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_items_identifiers__,
+from __relational_items_identifiers__,
 lateral (
   select
     __relational_items__."id"::text as "0",
@@ -26,8 +29,11 @@ lateral (
   order by __relational_items__."id" asc
 ) as __relational_items_result__;
 
+with __relational_topics_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_topics_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_topics_identifiers__,
+from __relational_topics_identifiers__,
 lateral (
   select
     __relational_topics__."id"::text as "0",
@@ -41,8 +47,11 @@ lateral (
     )
 ) as __relational_topics_result__;
 
+with __relational_posts_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_posts_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_posts_identifiers__,
+from __relational_posts_identifiers__,
 lateral (
   select
     __relational_posts__."id"::text as "0",
@@ -56,8 +65,11 @@ lateral (
     )
 ) as __relational_posts_result__;
 
+with __relational_dividers_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_dividers_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_dividers_identifiers__,
+from __relational_dividers_identifiers__,
 lateral (
   select
     __relational_dividers__."id"::text as "0",
@@ -81,8 +93,11 @@ where
     true /* authorization checks */
   );
 
+with __relational_checklist_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_checklist_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_checklist_items_identifiers__,
+from __relational_checklist_items_identifiers__,
 lateral (
   select
     __relational_checklist_items__."id"::text as "0",
@@ -96,8 +111,11 @@ lateral (
     )
 ) as __relational_checklist_items_result__;
 
+with __relational_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_items_identifiers__,
+from __relational_items_identifiers__,
 lateral (
   select
     __relational_items__."id"::text as "0",
@@ -123,8 +141,11 @@ where
     true /* authorization checks */
   );
 
+with __relational_checklists_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_checklists_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_checklists_identifiers__,
+from __relational_checklists_identifiers__,
 lateral (
   select
     __relational_checklists__."id"::text as "0",

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested.sql
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested.sql
@@ -33,8 +33,11 @@ where (
 )
 order by __people__."person_id" asc;
 
+with __relational_topics_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_topics_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_topics_identifiers__,
+from __relational_topics_identifiers__,
 lateral (
   select
     __relational_topics__."id"::text as "0",
@@ -48,8 +51,11 @@ lateral (
     )
 ) as __relational_topics_result__;
 
+with __relational_posts_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_posts_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_posts_identifiers__,
+from __relational_posts_identifiers__,
 lateral (
   select
     __relational_posts__."id"::text as "0",
@@ -63,8 +69,11 @@ lateral (
     )
 ) as __relational_posts_result__;
 
+with __relational_dividers_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_dividers_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_dividers_identifiers__,
+from __relational_dividers_identifiers__,
 lateral (
   select
     __relational_dividers__."id"::text as "0",
@@ -88,8 +97,11 @@ where
     true /* authorization checks */
   );
 
+with __relational_checklist_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_checklist_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_checklist_items_identifiers__,
+from __relational_checklist_items_identifiers__,
 lateral (
   select
     __relational_checklist_items__."id"::text as "0",
@@ -113,8 +125,11 @@ where
     true /* authorization checks */
   );
 
+with __relational_checklists_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_checklists_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_checklists_identifiers__,
+from __relational_checklists_identifiers__,
 lateral (
   select
     __relational_checklists__."id"::text as "0",

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/basics-with-fragments.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/basics-with-fragments.deopt.sql
@@ -7,8 +7,11 @@ where (
 )
 order by __people__."person_id" asc;
 
+with __single_table_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __single_table_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __single_table_items_identifiers__,
+from __single_table_items_identifiers__,
 lateral (
   select
     __single_table_items__."id"::text as "0",

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/basics.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/basics.deopt.sql
@@ -7,8 +7,11 @@ where (
 )
 order by __people__."person_id" asc;
 
+with __single_table_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __single_table_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __single_table_items_identifiers__,
+from __single_table_items_identifiers__,
 lateral (
   select
     __single_table_items__."id"::text as "0",

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more-fragments.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more-fragments.deopt.sql
@@ -7,8 +7,11 @@ where (
 )
 order by __people__."person_id" asc;
 
+with __single_table_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __single_table_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __single_table_items_identifiers__,
+from __single_table_items_identifiers__,
 lateral (
   select
     __single_table_items__."id"::text as "0",
@@ -36,8 +39,11 @@ lateral (
   order by __single_table_items__."id" asc
 ) as __single_table_items_result__;
 
+with __single_table_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __single_table_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __single_table_items_identifiers__,
+from __single_table_items_identifiers__,
 lateral (
   select
     __single_table_items__."type"::text as "0",
@@ -62,8 +68,11 @@ lateral (
     )
 ) as __single_table_items_result__;
 
+with __people_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __people_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __people_identifiers__,
+from __people_identifiers__,
 lateral (
   select
     __people__."username" as "0",
@@ -77,8 +86,11 @@ lateral (
     )
 ) as __people_result__;
 
+with __people_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __people_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __people_identifiers__,
+from __people_identifiers__,
 lateral (
   select
     __people__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more.deopt.sql
@@ -7,8 +7,11 @@ where (
 )
 order by __people__."person_id" asc;
 
+with __single_table_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __single_table_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __single_table_items_identifiers__,
+from __single_table_items_identifiers__,
 lateral (
   select
     __single_table_items__."id"::text as "0",
@@ -32,8 +35,11 @@ lateral (
   order by __single_table_items__."id" asc
 ) as __single_table_items_result__;
 
+with __single_table_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __single_table_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __single_table_items_identifiers__,
+from __single_table_items_identifiers__,
 lateral (
   select
     __single_table_items__."type"::text as "0",
@@ -54,8 +60,11 @@ lateral (
     )
 ) as __single_table_items_result__;
 
+with __people_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __people_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __people_identifiers__,
+from __people_identifiers__,
 lateral (
   select
     __people__."username" as "0",
@@ -69,8 +78,11 @@ lateral (
     )
 ) as __people_result__;
 
+with __people_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __people_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __people_identifiers__,
+from __people_identifiers__,
 lateral (
   select
     __people__."username" as "0",

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested.deopt.sql
@@ -7,8 +7,11 @@ where (
 )
 order by __people__."person_id" asc;
 
+with __single_table_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __single_table_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __single_table_items_identifiers__,
+from __single_table_items_identifiers__,
 lateral (
   select
     __single_table_items__."id"::text as "0",
@@ -26,8 +29,11 @@ lateral (
   order by __single_table_items__."id" asc
 ) as __single_table_items_result__;
 
+with __single_table_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __single_table_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __single_table_items_identifiers__,
+from __single_table_items_identifiers__,
 lateral (
   select
     __single_table_items__."type"::text as "0",

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilities.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilities.deopt.sql
@@ -70,8 +70,11 @@ where
     true /* authorization checks */
   );
 
+with __third_party_vulnerabilities_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __third_party_vulnerabilities_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __third_party_vulnerabilities_identifiers__,
+from __third_party_vulnerabilities_identifiers__,
 lateral (
   select
     __third_party_vulnerabilities__."cvss_score"::text as "0",

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilities.sql
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilities.sql
@@ -70,8 +70,11 @@ where
     true /* authorization checks */
   );
 
+with __third_party_vulnerabilities_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __third_party_vulnerabilities_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __third_party_vulnerabilities_identifiers__,
+from __third_party_vulnerabilities_identifiers__,
 lateral (
   select
     __third_party_vulnerabilities__."cvss_score"::text as "0",

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilitiesConnection.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilitiesConnection.deopt.sql
@@ -51,8 +51,11 @@ from (
 ) __vulnerabilities__
 
 
+with __first_party_vulnerabilities_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __first_party_vulnerabilities_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __first_party_vulnerabilities_identifiers__,
+from __first_party_vulnerabilities_identifiers__,
 lateral (
   select
     __first_party_vulnerabilities__."cvss_score"::text as "0",
@@ -69,8 +72,11 @@ lateral (
     )
 ) as __first_party_vulnerabilities_result__;
 
+with __third_party_vulnerabilities_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __third_party_vulnerabilities_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __third_party_vulnerabilities_identifiers__,
+from __third_party_vulnerabilities_identifiers__,
 lateral (
   select
     __third_party_vulnerabilities__."cvss_score"::text as "0",

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilitiesConnection.sql
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilitiesConnection.sql
@@ -51,8 +51,11 @@ from (
 ) __vulnerabilities__
 
 
+with __first_party_vulnerabilities_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __first_party_vulnerabilities_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __first_party_vulnerabilities_identifiers__,
+from __first_party_vulnerabilities_identifiers__,
 lateral (
   select
     __first_party_vulnerabilities__."cvss_score"::text as "0",
@@ -69,8 +72,11 @@ lateral (
     )
 ) as __first_party_vulnerabilities_result__;
 
+with __third_party_vulnerabilities_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __third_party_vulnerabilities_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __third_party_vulnerabilities_identifiers__,
+from __third_party_vulnerabilities_identifiers__,
 lateral (
   select
     __third_party_vulnerabilities__."cvss_score"::text as "0",

--- a/grafast/dataplan-pg/__tests__/queries/unions-table/bookmarks.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/unions-table/bookmarks.deopt.sql
@@ -26,8 +26,11 @@ where
     true /* authorization checks */
   );
 
+with __people_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __people_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __people_identifiers__,
+from __people_identifiers__,
 lateral (
   select
     __people__."username" as "0",

--- a/grafast/dataplan-pg/src/steps/pgSelect.ts
+++ b/grafast/dataplan-pg/src/steps/pgSelect.ts
@@ -3333,20 +3333,23 @@ function buildTheQuery<
        * clause.
        */
       const text = `\
+with ${identifiersAliasText} as materialized (
+  select ids.ordinality - 1 as idx${
+    queryValues.length > 0
+      ? `, ${queryValues
+          .map(({ codec }, idx) => {
+            return `(ids.value->>${idx})::${
+              sql.compile(codec.sqlType).text
+            } as "id${idx}"`;
+          })
+          .join(", ")}`
+      : ""
+  } from json_array_elements($${
+    rawSqlValues.length + 1
+  }::json) with ordinality as ids
+)
 select ${wrapperAliasText}.*
-from (select ids.ordinality - 1 as idx${
-        queryValues.length > 0
-          ? `, ${queryValues
-              .map(({ codec }, idx) => {
-                return `(ids.value->>${idx})::${
-                  sql.compile(codec.sqlType).text
-                } as "id${idx}"`;
-              })
-              .join(", ")}`
-          : ""
-      } from json_array_elements($${
-        rawSqlValues.length + 1
-      }::json) with ordinality as ids) as ${identifiersAliasText},
+from ${identifiersAliasText},
 ${lateralText};`;
 
       return { text, rawSqlValues, identifierIndex };

--- a/grafast/dataplan-pg/src/steps/pgUnionAll.ts
+++ b/grafast/dataplan-pg/src/steps/pgUnionAll.ts
@@ -1768,20 +1768,23 @@ ${unionHaving}\
        * clause.
        */
       const text = `\
+with ${identifiersAliasText} as materialized (
+  select ids.ordinality - 1 as idx${
+    queryValues.length > 0
+      ? `, ${queryValues
+          .map(({ codec }, idx) => {
+            return `(ids.value->>${idx})::${
+              sql.compile(codec.sqlType).text
+            } as "id${idx}"`;
+          })
+          .join(", ")}`
+      : ""
+  } from json_array_elements($${
+    rawSqlValues.length + 1
+  }::json) with ordinality as ids
+)
 select ${wrapperAliasText}.*
-from (select ids.ordinality - 1 as idx${
-        queryValues.length > 0
-          ? `, ${queryValues
-              .map(({ codec }, idx) => {
-                return `(ids.value->>${idx})::${
-                  sql.compile(codec.sqlType).text
-                } as "id${idx}"`;
-              })
-              .join(", ")}`
-          : ""
-      } from json_array_elements($${
-        rawSqlValues.length + 1
-      }::json) with ordinality as ids) as ${identifiersAliasText},
+from ${identifiersAliasText},
 ${lateralText};`;
 
       return {

--- a/postgraphile/postgraphile/__tests__/mutations/v4/nested_arrays.createT.sql
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/nested_arrays.createT.sql
@@ -2,8 +2,11 @@ insert into "nested_arrays"."t" as __t__ ("v") values ($1::"nested_arrays"."work
   __t__."k"::text as "0",
   __t__."v"::text as "1";
 
+with __frmcdc_work_hour_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"nested_arrays"."work_hour"[] as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __frmcdc_work_hour_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"nested_arrays"."work_hour"[] as "id0" from json_array_elements($1::json) with ordinality as ids) as __frmcdc_work_hour_identifiers__,
+from __frmcdc_work_hour_identifiers__,
 lateral (
   select
     __frmcdc_work_hour__."from_hours"::text as "0",

--- a/postgraphile/postgraphile/__tests__/mutations/v4/nested_arrays.updateT.sql
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/nested_arrays.updateT.sql
@@ -2,8 +2,11 @@ update "nested_arrays"."t" as __t__ set "v" = $1::"nested_arrays"."working_hours
   __t__."k"::text as "0",
   __t__."v"::text as "1";
 
+with __frmcdc_work_hour_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"nested_arrays"."work_hour"[] as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __frmcdc_work_hour_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"nested_arrays"."work_hour"[] as "id0" from json_array_elements($1::json) with ordinality as ids) as __frmcdc_work_hour_identifiers__,
+from __frmcdc_work_hour_identifiers__,
 lateral (
   select
     __frmcdc_work_hour__."from_hours"::text as "0",

--- a/postgraphile/postgraphile/__tests__/mutations/v4/procedure-mutation.sql
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/procedure-mutation.sql
@@ -222,8 +222,11 @@ select
   )::text end) as "2"
 from "a"."post_many"($1::"a"."post"[]) as __post_many__;
 
+with __frmcdc_comptype_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"a"."comptype"[] as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __frmcdc_comptype_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"a"."comptype"[] as "id0" from json_array_elements($1::json) with ordinality as ids) as __frmcdc_comptype_identifiers__,
+from __frmcdc_comptype_identifiers__,
 lateral (
   select
     to_char(__frmcdc_comptype__."schedule", 'YYYY-MM-DD"T"HH24:MI:SS.USTZH:TZM'::text) as "0",

--- a/postgraphile/postgraphile/__tests__/mutations/v4/types.sql
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/types.sql
@@ -334,8 +334,11 @@ select
   __type_function_list_mutation__."ltree_array"::text as "49"
 from unnest("b"."type_function_list_mutation"()) as __type_function_list_mutation__;
 
+with __frmcdc_compound_type_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"c"."compound_type" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __frmcdc_compound_type_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"c"."compound_type" as "id0" from json_array_elements($1::json) with ordinality as ids) as __frmcdc_compound_type_identifiers__,
+from __frmcdc_compound_type_identifiers__,
 lateral (
   select
     __frmcdc_compound_type__."a"::text as "0",
@@ -350,8 +353,11 @@ lateral (
   from (select (__frmcdc_compound_type_identifiers__."id0").*) as __frmcdc_compound_type__
 ) as __frmcdc_compound_type_result__;
 
+with __frmcdc_nested_compound_type_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"b"."nested_compound_type" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __frmcdc_nested_compound_type_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"b"."nested_compound_type" as "id0" from json_array_elements($1::json) with ordinality as ids) as __frmcdc_nested_compound_type_identifiers__,
+from __frmcdc_nested_compound_type_identifiers__,
 lateral (
   select
     __frmcdc_nested_compound_type__."baz_buz"::text as "0",
@@ -380,8 +386,11 @@ lateral (
   on TRUE
 ) as __frmcdc_nested_compound_type_result__;
 
+with __frmcdc_compound_type_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"c"."compound_type" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __frmcdc_compound_type_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"c"."compound_type" as "id0" from json_array_elements($1::json) with ordinality as ids) as __frmcdc_compound_type_identifiers__,
+from __frmcdc_compound_type_identifiers__,
 lateral (
   select
     __frmcdc_compound_type__."a"::text as "0",
@@ -396,8 +405,11 @@ lateral (
   from (select (__frmcdc_compound_type_identifiers__."id0").*) as __frmcdc_compound_type__
 ) as __frmcdc_compound_type_result__;
 
+with __frmcdc_nested_compound_type_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"b"."nested_compound_type" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __frmcdc_nested_compound_type_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"b"."nested_compound_type" as "id0" from json_array_elements($1::json) with ordinality as ids) as __frmcdc_nested_compound_type_identifiers__,
+from __frmcdc_nested_compound_type_identifiers__,
 lateral (
   select
     __frmcdc_nested_compound_type__."baz_buz"::text as "0",
@@ -426,8 +438,11 @@ lateral (
   on TRUE
 ) as __frmcdc_nested_compound_type_result__;
 
+with __post_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __post_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __post_identifiers__,
+from __post_identifiers__,
 lateral (
   select
     __post__."id"::text as "0",
@@ -439,8 +454,11 @@ lateral (
   )
 ) as __post_result__;
 
+with __post_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __post_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __post_identifiers__,
+from __post_identifiers__,
 lateral (
   select
     __post__."id"::text as "0",
@@ -576,8 +594,11 @@ select
   __type_function_connection_mutation__."ltree_array"::text as "49"
 from "b"."type_function_connection_mutation"() as __type_function_connection_mutation__;
 
+with __frmcdc_compound_type_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"c"."compound_type" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __frmcdc_compound_type_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"c"."compound_type" as "id0" from json_array_elements($1::json) with ordinality as ids) as __frmcdc_compound_type_identifiers__,
+from __frmcdc_compound_type_identifiers__,
 lateral (
   select
     __frmcdc_compound_type__."a"::text as "0",
@@ -592,8 +613,11 @@ lateral (
   from (select (__frmcdc_compound_type_identifiers__."id0").*) as __frmcdc_compound_type__
 ) as __frmcdc_compound_type_result__;
 
+with __frmcdc_nested_compound_type_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"b"."nested_compound_type" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __frmcdc_nested_compound_type_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"b"."nested_compound_type" as "id0" from json_array_elements($1::json) with ordinality as ids) as __frmcdc_nested_compound_type_identifiers__,
+from __frmcdc_nested_compound_type_identifiers__,
 lateral (
   select
     __frmcdc_nested_compound_type__."baz_buz"::text as "0",
@@ -622,8 +646,11 @@ lateral (
   on TRUE
 ) as __frmcdc_nested_compound_type_result__;
 
+with __frmcdc_compound_type_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"c"."compound_type" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __frmcdc_compound_type_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"c"."compound_type" as "id0" from json_array_elements($1::json) with ordinality as ids) as __frmcdc_compound_type_identifiers__,
+from __frmcdc_compound_type_identifiers__,
 lateral (
   select
     __frmcdc_compound_type__."a"::text as "0",
@@ -638,8 +665,11 @@ lateral (
   from (select (__frmcdc_compound_type_identifiers__."id0").*) as __frmcdc_compound_type__
 ) as __frmcdc_compound_type_result__;
 
+with __frmcdc_nested_compound_type_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"b"."nested_compound_type" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __frmcdc_nested_compound_type_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"b"."nested_compound_type" as "id0" from json_array_elements($1::json) with ordinality as ids) as __frmcdc_nested_compound_type_identifiers__,
+from __frmcdc_nested_compound_type_identifiers__,
 lateral (
   select
     __frmcdc_nested_compound_type__."baz_buz"::text as "0",
@@ -668,8 +698,11 @@ lateral (
   on TRUE
 ) as __frmcdc_nested_compound_type_result__;
 
+with __post_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __post_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __post_identifiers__,
+from __post_identifiers__,
 lateral (
   select
     __post__."id"::text as "0",
@@ -681,8 +714,11 @@ lateral (
   )
 ) as __post_result__;
 
+with __post_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __post_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __post_identifiers__,
+from __post_identifiers__,
 lateral (
   select
     __post__."id"::text as "0",

--- a/postgraphile/postgraphile/__tests__/queries/plugins/issue_2212.sql
+++ b/postgraphile/postgraphile/__tests__/queries/plugins/issue_2212.sql
@@ -10,8 +10,11 @@ select user_id::text, phone from issue_2212.user_contacts where user_id = any($1
 
 select phone_e164, sum(amount_cents) as sum from issue_2212.orders where phone_e164 = any($1::text[]) group by phone_e164;
 
+with __orders_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"text"[] as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __orders_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"text"[] as "id0" from json_array_elements($1::json) with ordinality as ids) as __orders_identifiers__,
+from __orders_identifiers__,
 lateral (
   select
     __orders__."id"::text as "0",

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/only.sql
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/only.sql
@@ -41,8 +41,11 @@ from (
 ) __application__
 
 
+with __aws_applications_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __aws_applications_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __aws_applications_identifiers__,
+from __aws_applications_identifiers__,
 lateral (
   select
     __aws_applications__."aws_id" as "0",
@@ -54,8 +57,11 @@ lateral (
   )
 ) as __aws_applications_result__;
 
+with __gcp_applications_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __gcp_applications_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __gcp_applications_identifiers__,
+from __gcp_applications_identifiers__,
 lateral (
   select
     __gcp_applications__."gcp_id" as "0",
@@ -67,8 +73,11 @@ lateral (
   )
 ) as __gcp_applications_result__;
 
+with __union_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __union_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+from __union_identifiers__,
 lateral (
   select
     __vulnerabilities__."0" as "0",
@@ -102,8 +111,11 @@ lateral (
   ) __vulnerabilities__
 ) as __union_result__;
 
+with __union_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __union_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+from __union_identifiers__,
 lateral (
   select
     __vulnerabilities__."0" as "0",
@@ -137,8 +149,11 @@ lateral (
   ) __vulnerabilities__
 ) as __union_result__;
 
+with __third_party_vulnerabilities_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __third_party_vulnerabilities_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __third_party_vulnerabilities_identifiers__,
+from __third_party_vulnerabilities_identifiers__,
 lateral (
   select
     __third_party_vulnerabilities__."id"::text as "0",

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-condition.sql
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-condition.sql
@@ -5,8 +5,11 @@ from "polymorphic"."people" as __people__
 order by __people__."person_id" asc
 limit 4;
 
+with __union_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($5::json) with ordinality as ids
+)
 select __union_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($5::json) with ordinality as ids) as __union_identifiers__,
+from __union_identifiers__,
 lateral (
   select
     __applications__."0" as "0",

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-order.sql
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-order.sql
@@ -5,8 +5,11 @@ from "polymorphic"."people" as __people__
 order by __people__."person_id" asc
 limit 4;
 
+with __union_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __union_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+from __union_identifiers__,
 lateral (
   select
     __applications__."0" as "0",
@@ -74,8 +77,11 @@ lateral (
   ) __applications__
 ) as __union_result__;
 
+with __aws_applications_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __aws_applications_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __aws_applications_identifiers__,
+from __aws_applications_identifiers__,
 lateral (
   select
     __aws_applications__."id"::text as "0",
@@ -88,8 +94,11 @@ lateral (
   )
 ) as __aws_applications_result__;
 
+with __gcp_applications_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __gcp_applications_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __gcp_applications_identifiers__,
+from __gcp_applications_identifiers__,
 lateral (
   select
     __gcp_applications__."id"::text as "0",

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-page-2.sql
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-page-2.sql
@@ -5,8 +5,11 @@ from "polymorphic"."people" as __people__
 order by __people__."person_id" asc
 limit 4;
 
+with __union_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($3::json) with ordinality as ids
+)
 select __union_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($3::json) with ordinality as ids) as __union_identifiers__,
+from __union_identifiers__,
 lateral (
   select
     __applications__."0" as "0",
@@ -75,8 +78,11 @@ lateral (
   ) __applications__
 ) as __union_result__;
 
+with __aws_applications_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __aws_applications_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __aws_applications_identifiers__,
+from __aws_applications_identifiers__,
 lateral (
   select
     __aws_applications__."id"::text as "0",
@@ -94,8 +100,11 @@ where (
   __gcp_applications__."id" = $1::"int4"
 );
 
+with __union_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __union_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+from __union_identifiers__,
 lateral (
   select
     __vulnerabilities__."0" as "0",
@@ -210,8 +219,11 @@ from (
 ) __vulnerabilities__
 
 
+with __first_party_vulnerabilities_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __first_party_vulnerabilities_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __first_party_vulnerabilities_identifiers__,
+from __first_party_vulnerabilities_identifiers__,
 lateral (
   select
     __first_party_vulnerabilities__."id"::text as "0",

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-totalCount.sql
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-totalCount.sql
@@ -5,8 +5,11 @@ from "polymorphic"."people" as __people__
 order by __people__."person_id" asc
 limit 4;
 
+with __union_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __union_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+from __union_identifiers__,
 lateral (
   select
     (count(*))::text as "0",

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-vuln-totalCount.sql
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-vuln-totalCount.sql
@@ -5,8 +5,11 @@ from "polymorphic"."people" as __people__
 order by __people__."person_id" asc
 limit 4;
 
+with __union_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __union_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+from __union_identifiers__,
 lateral (
   select
     __applications__."0" as "0",
@@ -54,8 +57,11 @@ lateral (
   ) __applications__
 ) as __union_result__;
 
+with __aws_applications_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __aws_applications_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __aws_applications_identifiers__,
+from __aws_applications_identifiers__,
 lateral (
   select
     __aws_applications__."id"::text as "0",
@@ -66,8 +72,11 @@ lateral (
   )
 ) as __aws_applications_result__;
 
+with __gcp_applications_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __gcp_applications_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __gcp_applications_identifiers__,
+from __gcp_applications_identifiers__,
 lateral (
   select
     __gcp_applications__."id"::text as "0",
@@ -78,8 +87,11 @@ lateral (
   )
 ) as __gcp_applications_result__;
 
+with __union_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __union_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+from __union_identifiers__,
 lateral (
   select
     (count(*))::text as "0",
@@ -133,8 +145,11 @@ lateral (
   ) __vulnerabilities__
 ) as __union_result__;
 
+with __union_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __union_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+from __union_identifiers__,
 lateral (
   select
     (count(*))::text as "0",

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.sql
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.sql
@@ -5,8 +5,11 @@ from "polymorphic"."people" as __people__
 order by __people__."person_id" asc
 limit 4;
 
+with __union_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __union_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+from __union_identifiers__,
 lateral (
   select
     __applications__."0" as "0",
@@ -54,8 +57,11 @@ lateral (
   ) __applications__
 ) as __union_result__;
 
+with __union_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __union_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+from __union_identifiers__,
 lateral (
   select
     (count(*))::text as "0",
@@ -101,8 +107,11 @@ lateral (
   ) __applications__
 ) as __union_result__;
 
+with __aws_applications_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __aws_applications_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __aws_applications_identifiers__,
+from __aws_applications_identifiers__,
 lateral (
   select
     __aws_applications__."id"::text as "0",
@@ -113,8 +122,11 @@ lateral (
   )
 ) as __aws_applications_result__;
 
+with __gcp_applications_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __gcp_applications_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __gcp_applications_identifiers__,
+from __gcp_applications_identifiers__,
 lateral (
   select
     __gcp_applications__."id"::text as "0",
@@ -125,8 +137,11 @@ lateral (
   )
 ) as __gcp_applications_result__;
 
+with __aws_applications_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __aws_applications_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __aws_applications_identifiers__,
+from __aws_applications_identifiers__,
 lateral (
   select
     __aws_applications__."aws_id" as "0",
@@ -141,8 +156,11 @@ lateral (
   )
 ) as __aws_applications_result__;
 
+with __gcp_applications_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __gcp_applications_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __gcp_applications_identifiers__,
+from __gcp_applications_identifiers__,
 lateral (
   select
     __gcp_applications__."gcp_id" as "0",
@@ -157,8 +175,11 @@ lateral (
   )
 ) as __gcp_applications_result__;
 
+with __union_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0", (ids.value->>1)::"int4" as "id1" from json_array_elements($1::json) with ordinality as ids
+)
 select __union_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0", (ids.value->>1)::"int4" as "id1" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+from __union_identifiers__,
 lateral (
   select
     __owner__."0" as "0",
@@ -206,8 +227,11 @@ lateral (
   ) __owner__
 ) as __union_result__;
 
+with __union_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __union_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+from __union_identifiers__,
 lateral (
   select
     __vulnerabilities__."0" as "0",
@@ -263,8 +287,11 @@ lateral (
   ) __vulnerabilities__
 ) as __union_result__;
 
+with __union_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __union_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+from __union_identifiers__,
 lateral (
   select
     (count(*))::text as "0",
@@ -318,8 +345,11 @@ lateral (
   ) __vulnerabilities__
 ) as __union_result__;
 
+with __union_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0", (ids.value->>1)::"int4" as "id1" from json_array_elements($1::json) with ordinality as ids
+)
 select __union_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0", (ids.value->>1)::"int4" as "id1" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+from __union_identifiers__,
 lateral (
   select
     __owner__."0" as "0",
@@ -367,8 +397,11 @@ lateral (
   ) __owner__
 ) as __union_result__;
 
+with __union_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __union_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+from __union_identifiers__,
 lateral (
   select
     __vulnerabilities__."0" as "0",
@@ -424,8 +457,11 @@ lateral (
   ) __vulnerabilities__
 ) as __union_result__;
 
+with __union_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __union_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+from __union_identifiers__,
 lateral (
   select
     (count(*))::text as "0",
@@ -479,8 +515,11 @@ lateral (
   ) __vulnerabilities__
 ) as __union_result__;
 
+with __people_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __people_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __people_identifiers__,
+from __people_identifiers__,
 lateral (
   select
     __people__."person_id"::text as "0",
@@ -492,8 +531,11 @@ lateral (
   )
 ) as __people_result__;
 
+with __first_party_vulnerabilities_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __first_party_vulnerabilities_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __first_party_vulnerabilities_identifiers__,
+from __first_party_vulnerabilities_identifiers__,
 lateral (
   select
     __first_party_vulnerabilities__."team_name" as "0",
@@ -507,8 +549,11 @@ lateral (
   )
 ) as __first_party_vulnerabilities_result__;
 
+with __third_party_vulnerabilities_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __third_party_vulnerabilities_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __third_party_vulnerabilities_identifiers__,
+from __third_party_vulnerabilities_identifiers__,
 lateral (
   select
     __third_party_vulnerabilities__."vendor_name" as "0",
@@ -522,8 +567,11 @@ lateral (
   )
 ) as __third_party_vulnerabilities_result__;
 
+with __first_party_vulnerabilities_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __first_party_vulnerabilities_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __first_party_vulnerabilities_identifiers__,
+from __first_party_vulnerabilities_identifiers__,
 lateral (
   select
     __first_party_vulnerabilities__."cvss_score"::text as "0",
@@ -536,8 +584,11 @@ lateral (
   )
 ) as __first_party_vulnerabilities_result__;
 
+with __third_party_vulnerabilities_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __third_party_vulnerabilities_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __third_party_vulnerabilities_identifiers__,
+from __third_party_vulnerabilities_identifiers__,
 lateral (
   select
     __third_party_vulnerabilities__."cvss_score"::text as "0",

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/relational-functions.sql
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/relational-functions.sql
@@ -67,8 +67,11 @@ on (
 left outer join "polymorphic"."relational_topics_parent_fn"(__relational_topic_by_id_fn__) as __relational_topics_parent_fn__
 on TRUE;
 
+with __relational_topics_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_topics_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_topics_identifiers__,
+from __relational_topics_identifiers__,
 lateral (
   select
     __relational_topics__."title" as "0",
@@ -84,8 +87,11 @@ lateral (
   )
 ) as __relational_topics_result__;
 
+with __relational_posts_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_posts_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_posts_identifiers__,
+from __relational_posts_identifiers__,
 lateral (
   select
     __relational_posts__."title" as "0",
@@ -98,8 +104,11 @@ lateral (
   )
 ) as __relational_posts_result__;
 
+with __relational_dividers_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_dividers_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_dividers_identifiers__,
+from __relational_dividers_identifiers__,
 lateral (
   select
     __relational_dividers__."color" as "0",
@@ -118,8 +127,11 @@ where (
   __relational_checklists__."checklist_item_id" = $1::"int4"
 );
 
+with __relational_checklist_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_checklist_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_checklist_items_identifiers__,
+from __relational_checklist_items_identifiers__,
 lateral (
   select
     __relational_checklist_items__."description" as "0",
@@ -138,8 +150,11 @@ where (
   __relational_topics__."topic_item_id" = $1::"int4"
 );
 
+with __relational_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_items_identifiers__,
+from __relational_items_identifiers__,
 lateral (
   select
     __relational_items__."id"::text as "0",
@@ -152,8 +167,11 @@ lateral (
   )
 ) as __relational_items_result__;
 
+with __relational_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_items_identifiers__,
+from __relational_items_identifiers__,
 lateral (
   select
     __relational_items__."id"::text as "0",
@@ -166,8 +184,11 @@ lateral (
   )
 ) as __relational_items_result__;
 
+with __relational_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_items_identifiers__,
+from __relational_items_identifiers__,
 lateral (
   select
     __relational_items__."id"::text as "0",
@@ -189,8 +210,11 @@ where (
   __relational_items_2."id" = $1::"int4"
 );
 
+with __relational_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_items_identifiers__,
+from __relational_items_identifiers__,
 lateral (
   select
     __relational_items__."id"::text as "0",
@@ -203,8 +227,11 @@ lateral (
   )
 ) as __relational_items_result__;
 
+with __relational_topics_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_topics_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_topics_identifiers__,
+from __relational_topics_identifiers__,
 lateral (
   select
     __relational_topics__."title" as "0",
@@ -215,8 +242,11 @@ lateral (
   )
 ) as __relational_topics_result__;
 
+with __relational_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_items_identifiers__,
+from __relational_items_identifiers__,
 lateral (
   select
     __relational_items__."type"::text as "0",
@@ -229,8 +259,11 @@ lateral (
   )
 ) as __relational_items_result__;
 
+with __relational_topics_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_topics_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_topics_identifiers__,
+from __relational_topics_identifiers__,
 lateral (
   select
     __relational_topics__."title" as "0",
@@ -253,8 +286,11 @@ where (
   __relational_posts__."post_item_id" = $1::"int4"
 );
 
+with __relational_checklists_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_checklists_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_checklists_identifiers__,
+from __relational_checklists_identifiers__,
 lateral (
   select
     __relational_checklists__."checklist_item_id"::text as "0",

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/relay.polyroot_with_related_poly.simple.sql
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/relay.polyroot_with_related_poly.simple.sql
@@ -4,8 +4,11 @@ select
 from "polymorphic"."relational_items" as __relational_items__
 order by __relational_items__."id" asc;
 
+with __relational_topics_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_topics_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_topics_identifiers__,
+from __relational_topics_identifiers__,
 lateral (
   select
     __relational_topics__."topic_item_id"::text as "0",
@@ -16,8 +19,11 @@ lateral (
   )
 ) as __relational_topics_result__;
 
+with __relational_posts_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_posts_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_posts_identifiers__,
+from __relational_posts_identifiers__,
 lateral (
   select
     __relational_posts__."post_item_id"::text as "0",
@@ -28,8 +34,11 @@ lateral (
   )
 ) as __relational_posts_result__;
 
+with __relational_dividers_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_dividers_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_dividers_identifiers__,
+from __relational_dividers_identifiers__,
 lateral (
   select
     __relational_dividers__."divider_item_id"::text as "0",
@@ -47,8 +56,11 @@ where (
   __relational_checklists__."checklist_item_id" = $1::"int4"
 );
 
+with __relational_checklist_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_checklist_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_checklist_items_identifiers__,
+from __relational_checklist_items_identifiers__,
 lateral (
   select
     __relational_checklist_items__."checklist_item_item_id"::text as "0",
@@ -59,8 +71,11 @@ lateral (
   )
 ) as __relational_checklist_items_result__;
 
+with __relational_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_items_identifiers__,
+from __relational_items_identifiers__,
 lateral (
   select
     __relational_items__."id"::text as "0",
@@ -73,8 +88,11 @@ lateral (
   )
 ) as __relational_items_result__;
 
+with __relational_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_items_identifiers__,
+from __relational_items_identifiers__,
 lateral (
   select
     __relational_items__."id"::text as "0",
@@ -87,8 +105,11 @@ lateral (
   )
 ) as __relational_items_result__;
 
+with __relational_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_items_identifiers__,
+from __relational_items_identifiers__,
 lateral (
   select
     __relational_items__."id"::text as "0",
@@ -110,8 +131,11 @@ where (
   __relational_items_2."id" = $1::"int4"
 );
 
+with __relational_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_items_identifiers__,
+from __relational_items_identifiers__,
 lateral (
   select
     __relational_items__."id"::text as "0",
@@ -124,8 +148,11 @@ lateral (
   )
 ) as __relational_items_result__;
 
+with __relational_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_items_identifiers__,
+from __relational_items_identifiers__,
 lateral (
   select
     __relational_items__."type"::text as "0",
@@ -144,8 +171,11 @@ where (
   __relational_posts__."post_item_id" = $1::"int4"
 );
 
+with __relational_checklists_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_checklists_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_checklists_identifiers__,
+from __relational_checklists_identifiers__,
 lateral (
   select
     __relational_checklists__."checklist_item_id"::text as "0",

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/relay.polyroot_with_related_poly.sql
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/relay.polyroot_with_related_poly.sql
@@ -61,8 +61,11 @@ where (
 )
 order by __relational_item_relations__."id" asc;
 
+with __relational_topics_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_topics_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_topics_identifiers__,
+from __relational_topics_identifiers__,
 lateral (
   select
     __relational_topics__."topic_item_id"::text as "0",
@@ -73,8 +76,11 @@ lateral (
   )
 ) as __relational_topics_result__;
 
+with __relational_posts_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_posts_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_posts_identifiers__,
+from __relational_posts_identifiers__,
 lateral (
   select
     __relational_posts__."post_item_id"::text as "0",
@@ -85,8 +91,11 @@ lateral (
   )
 ) as __relational_posts_result__;
 
+with __relational_dividers_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_dividers_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_dividers_identifiers__,
+from __relational_dividers_identifiers__,
 lateral (
   select
     __relational_dividers__."divider_item_id"::text as "0",
@@ -104,8 +113,11 @@ where (
   __relational_checklists__."checklist_item_id" = $1::"int4"
 );
 
+with __relational_checklist_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_checklist_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_checklist_items_identifiers__,
+from __relational_checklist_items_identifiers__,
 lateral (
   select
     __relational_checklist_items__."checklist_item_item_id"::text as "0",
@@ -123,8 +135,11 @@ where (
   __relational_checklist_items__."checklist_item_item_id" = $1::"int4"
 );
 
+with __relational_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_items_identifiers__,
+from __relational_items_identifiers__,
 lateral (
   select
     __relational_items__."id"::text as "0",
@@ -137,8 +152,11 @@ lateral (
   )
 ) as __relational_items_result__;
 
+with __relational_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_items_identifiers__,
+from __relational_items_identifiers__,
 lateral (
   select
     __relational_items__."id"::text as "0",
@@ -151,8 +169,11 @@ lateral (
   )
 ) as __relational_items_result__;
 
+with __relational_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_items_identifiers__,
+from __relational_items_identifiers__,
 lateral (
   select
     __relational_items__."id"::text as "0",
@@ -174,8 +195,11 @@ where (
   __relational_items_2."id" = $1::"int4"
 );
 
+with __relational_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_items_identifiers__,
+from __relational_items_identifiers__,
 lateral (
   select
     __relational_items__."id"::text as "0",
@@ -188,8 +212,11 @@ lateral (
   )
 ) as __relational_items_result__;
 
+with __relational_items_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_items_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_items_identifiers__,
+from __relational_items_identifiers__,
 lateral (
   select
     __relational_items__."type"::text as "0",
@@ -208,8 +235,11 @@ where (
   __relational_posts__."post_item_id" = $1::"int4"
 );
 
+with __relational_checklists_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_checklists_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_checklists_identifiers__,
+from __relational_checklists_identifiers__,
 lateral (
   select
     __relational_checklists__."checklist_item_id"::text as "0",

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/simple-log-entries.sql
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/simple-log-entries.sql
@@ -5,8 +5,11 @@ select
 from "polymorphic"."log_entries" as __log_entries__
 order by __log_entries__."id" asc;
 
+with __union_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0", (ids.value->>1)::"int4" as "id1" from json_array_elements($1::json) with ordinality as ids
+)
 select __union_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0", (ids.value->>1)::"int4" as "id1" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+from __union_identifiers__,
 lateral (
   select
     __author__."0" as "0",
@@ -54,8 +57,11 @@ lateral (
   ) __author__
 ) as __union_result__;
 
+with __organizations_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __organizations_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __organizations_identifiers__,
+from __organizations_identifiers__,
 lateral (
   select
     __organizations__."name" as "0",
@@ -66,8 +72,11 @@ lateral (
   )
 ) as __organizations_result__;
 
+with __people_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __people_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __people_identifiers__,
+from __people_identifiers__,
 lateral (
   select
     __people__."username" as "0",

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns-ordering.sql
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns-ordering.sql
@@ -61,8 +61,11 @@ from (
 ) __vulnerability__
 
 
+with __first_party_vulnerabilities_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __first_party_vulnerabilities_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __first_party_vulnerabilities_identifiers__,
+from __first_party_vulnerabilities_identifiers__,
 lateral (
   select
     __first_party_vulnerabilities__."id"::text as "0",
@@ -75,8 +78,11 @@ lateral (
   )
 ) as __first_party_vulnerabilities_result__;
 
+with __third_party_vulnerabilities_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __third_party_vulnerabilities_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __third_party_vulnerabilities_identifiers__,
+from __third_party_vulnerabilities_identifiers__,
 lateral (
   select
     __third_party_vulnerabilities__."id"::text as "0",

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.deep.sql
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.deep.sql
@@ -185,8 +185,11 @@ from (
 ) __applications__
 
 
+with __aws_applications_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __aws_applications_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __aws_applications_identifiers__,
+from __aws_applications_identifiers__,
 lateral (
   select
     __aws_applications__."name" as "0",
@@ -206,8 +209,11 @@ where (
   __gcp_applications__."id" = $1::"int4"
 );
 
+with __union_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __union_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+from __union_identifiers__,
 lateral (
   select
     __vulnerabilities__."0" as "0",
@@ -322,8 +328,11 @@ from (
 ) __vulnerabilities__
 
 
+with __first_party_vulnerabilities_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __first_party_vulnerabilities_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __first_party_vulnerabilities_identifiers__,
+from __first_party_vulnerabilities_identifiers__,
 lateral (
   select
     __first_party_vulnerabilities__."name" as "0",
@@ -335,8 +344,11 @@ lateral (
   )
 ) as __first_party_vulnerabilities_result__;
 
+with __third_party_vulnerabilities_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __third_party_vulnerabilities_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __third_party_vulnerabilities_identifiers__,
+from __third_party_vulnerabilities_identifiers__,
 lateral (
   select
     __third_party_vulnerabilities__."name" as "0",
@@ -348,8 +360,11 @@ lateral (
   )
 ) as __third_party_vulnerabilities_result__;
 
+with __union_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __union_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+from __union_identifiers__,
 lateral (
   select
     __applications__."0" as "0",
@@ -409,8 +424,11 @@ lateral (
   ) __applications__
 ) as __union_result__;
 
+with __union_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __union_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+from __union_identifiers__,
 lateral (
   select
     __applications__."0" as "0",
@@ -470,8 +488,11 @@ lateral (
   ) __applications__
 ) as __union_result__;
 
+with __gcp_applications_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __gcp_applications_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __gcp_applications_identifiers__,
+from __gcp_applications_identifiers__,
 lateral (
   select
     __gcp_applications__."name" as "0",
@@ -483,8 +504,11 @@ lateral (
   )
 ) as __gcp_applications_result__;
 
+with __union_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __union_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+from __union_identifiers__,
 lateral (
   select
     __vulnerabilities__."0" as "0",
@@ -543,8 +567,11 @@ lateral (
   ) __vulnerabilities__
 ) as __union_result__;
 
+with __first_party_vulnerabilities_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __first_party_vulnerabilities_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __first_party_vulnerabilities_identifiers__,
+from __first_party_vulnerabilities_identifiers__,
 lateral (
   select
     __first_party_vulnerabilities__."name" as "0",
@@ -555,8 +582,11 @@ lateral (
   )
 ) as __first_party_vulnerabilities_result__;
 
+with __third_party_vulnerabilities_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __third_party_vulnerabilities_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __third_party_vulnerabilities_identifiers__,
+from __third_party_vulnerabilities_identifiers__,
 lateral (
   select
     __third_party_vulnerabilities__."name" as "0",

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.sql
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.sql
@@ -191,8 +191,11 @@ where (
   __first_party_vulnerabilities__."id" = $1::"int4"
 );
 
+with __third_party_vulnerabilities_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __third_party_vulnerabilities_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __third_party_vulnerabilities_identifiers__,
+from __third_party_vulnerabilities_identifiers__,
 lateral (
   select
     __third_party_vulnerabilities__."id"::text as "0",

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.union_owners.simple.sql
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.union_owners.simple.sql
@@ -44,8 +44,11 @@ from (
 ) __vulnerability__
 
 
+with __first_party_vulnerabilities_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __first_party_vulnerabilities_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __first_party_vulnerabilities_identifiers__,
+from __first_party_vulnerabilities_identifiers__,
 lateral (
   select
     __first_party_vulnerabilities__."id"::text as "0",
@@ -57,8 +60,11 @@ lateral (
   )
 ) as __first_party_vulnerabilities_result__;
 
+with __union_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __union_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+from __union_identifiers__,
 lateral (
   select
     __owners__."0" as "0",
@@ -174,8 +180,11 @@ lateral (
   ) __owners__
 ) as __union_result__;
 
+with __organizations_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __organizations_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __organizations_identifiers__,
+from __organizations_identifiers__,
 lateral (
   select
     __organizations__."organization_id"::text as "0",
@@ -187,8 +196,11 @@ lateral (
   )
 ) as __organizations_result__;
 
+with __people_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __people_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __people_identifiers__,
+from __people_identifiers__,
 lateral (
   select
     __people__."person_id"::text as "0",

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.union_owners.sql
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.union_owners.sql
@@ -44,8 +44,11 @@ from (
 ) __vulnerability__
 
 
+with __first_party_vulnerabilities_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __first_party_vulnerabilities_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __first_party_vulnerabilities_identifiers__,
+from __first_party_vulnerabilities_identifiers__,
 lateral (
   select
     __first_party_vulnerabilities__."id"::text as "0",
@@ -57,8 +60,11 @@ lateral (
   )
 ) as __first_party_vulnerabilities_result__;
 
+with __union_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __union_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+from __union_identifiers__,
 lateral (
   select
     __applications__."0" as "0",
@@ -114,8 +120,11 @@ lateral (
   ) __applications__
 ) as __union_result__;
 
+with __union_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __union_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+from __union_identifiers__,
 lateral (
   select
     __owners__."0" as "0",
@@ -231,8 +240,11 @@ lateral (
   ) __owners__
 ) as __union_result__;
 
+with __aws_applications_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __aws_applications_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __aws_applications_identifiers__,
+from __aws_applications_identifiers__,
 lateral (
   select
     __aws_applications__."id"::text as "0",
@@ -246,8 +258,11 @@ lateral (
   )
 ) as __aws_applications_result__;
 
+with __gcp_applications_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __gcp_applications_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __gcp_applications_identifiers__,
+from __gcp_applications_identifiers__,
 lateral (
   select
     __gcp_applications__."id"::text as "0",
@@ -261,8 +276,11 @@ lateral (
   )
 ) as __gcp_applications_result__;
 
+with __organizations_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __organizations_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __organizations_identifiers__,
+from __organizations_identifiers__,
 lateral (
   select
     __organizations__."organization_id"::text as "0",
@@ -274,8 +292,11 @@ lateral (
   )
 ) as __organizations_result__;
 
+with __people_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __people_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __people_identifiers__,
+from __people_identifiers__,
 lateral (
   select
     __people__."person_id"::text as "0",
@@ -287,8 +308,11 @@ lateral (
   )
 ) as __people_result__;
 
+with __union_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0", (ids.value->>1)::"int4" as "id1" from json_array_elements($1::json) with ordinality as ids
+)
 select __union_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0", (ids.value->>1)::"int4" as "id1" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+from __union_identifiers__,
 lateral (
   select
     __owner__."0" as "0",
@@ -336,8 +360,11 @@ lateral (
   ) __owner__
 ) as __union_result__;
 
+with __union_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0", (ids.value->>1)::"int4" as "id1" from json_array_elements($1::json) with ordinality as ids
+)
 select __union_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0", (ids.value->>1)::"int4" as "id1" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+from __union_identifiers__,
 lateral (
   select
     __owner__."0" as "0",

--- a/postgraphile/postgraphile/__tests__/queries/refs/books-editors-plural-ref.sql
+++ b/postgraphile/postgraphile/__tests__/queries/refs/books-editors-plural-ref.sql
@@ -3,8 +3,11 @@ select
 from "refs"."books" as __books__
 order by __books__."id" asc;
 
+with __people_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __people_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __people_identifiers__,
+from __people_identifiers__,
 lateral (
   select
     __people__."name" as "0",

--- a/postgraphile/postgraphile/__tests__/queries/refs/books-related-people-plural-ref.sql
+++ b/postgraphile/postgraphile/__tests__/queries/refs/books-related-people-plural-ref.sql
@@ -4,8 +4,11 @@ select
 from "refs"."books" as __books__
 order by __books__."id" asc;
 
+with __people_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __people_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __people_identifiers__,
+from __people_identifiers__,
 lateral (
   select
     __people__."name" as "0",

--- a/postgraphile/postgraphile/__tests__/queries/v4/composite_domains.sql
+++ b/postgraphile/postgraphile/__tests__/queries/v4/composite_domains.sql
@@ -36,8 +36,11 @@ left outer join lateral (select (__posts__."content").*) as __frmcdc_user_update
 on TRUE
 order by __posts__."id" asc;
 
+with __frmcdc_user_update_content_line_node_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"composite_domains"."user_update_content_line_node"[] as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __frmcdc_user_update_content_line_node_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"composite_domains"."user_update_content_line_node"[] as "id0" from json_array_elements($1::json) with ordinality as ids) as __frmcdc_user_update_content_line_node_identifiers__,
+from __frmcdc_user_update_content_line_node_identifiers__,
 lateral (
   select
     __frmcdc_user_update_content_line_node__."line_node_type"::text as "0",
@@ -46,8 +49,11 @@ lateral (
   from unnest(__frmcdc_user_update_content_line_node_identifiers__."id0") as __frmcdc_user_update_content_line_node__
 ) as __frmcdc_user_update_content_line_node_result__;
 
+with __frmcdc_user_update_content_line_node_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"composite_domains"."user_update_content_line_node"[] as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __frmcdc_user_update_content_line_node_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"composite_domains"."user_update_content_line_node"[] as "id0" from json_array_elements($1::json) with ordinality as ids) as __frmcdc_user_update_content_line_node_identifiers__,
+from __frmcdc_user_update_content_line_node_identifiers__,
 lateral (
   select
     __frmcdc_user_update_content_line_node__."line_node_type"::text as "0",

--- a/postgraphile/postgraphile/__tests__/queries/v4/issue2210.sql
+++ b/postgraphile/postgraphile/__tests__/queries/v4/issue2210.sql
@@ -7,8 +7,11 @@ select
 from "issue_2210"."some_messages"($1::"uuid") as __some_messages__
 limit 51;
 
+with __test_user_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __test_user_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"uuid" as "id0" from json_array_elements($1::json) with ordinality as ids) as __test_user_identifiers__,
+from __test_user_identifiers__,
 lateral (
   select
     __test_user__."id" as "0",

--- a/postgraphile/postgraphile/__tests__/queries/v4/js-reserved-keywords.sql
+++ b/postgraphile/postgraphile/__tests__/queries/v4/js-reserved-keywords.sql
@@ -41,8 +41,11 @@ select
 from "js_reserved"."relational_items" as __relational_items__
 order by __relational_items__."id" asc;
 
+with __relational_topics_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_topics_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_topics_identifiers__,
+from __relational_topics_identifiers__,
 lateral (
   select
     __relational_topics__."title" as "0",
@@ -53,8 +56,11 @@ lateral (
   )
 ) as __relational_topics_result__;
 
+with __relational_status_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __relational_status_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __relational_status_identifiers__,
+from __relational_status_identifiers__,
 lateral (
   select
     __relational_status__."note" as "0",

--- a/postgraphile/postgraphile/__tests__/queries/v4/nested_arrays.select.sql
+++ b/postgraphile/postgraphile/__tests__/queries/v4/nested_arrays.select.sql
@@ -4,8 +4,11 @@ select
 from "nested_arrays"."t" as __t__
 order by __t__."k" asc;
 
+with __frmcdc_work_hour_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"nested_arrays"."work_hour"[] as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __frmcdc_work_hour_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"nested_arrays"."work_hour"[] as "id0" from json_array_elements($1::json) with ordinality as ids) as __frmcdc_work_hour_identifiers__,
+from __frmcdc_work_hour_identifiers__,
 lateral (
   select
     __frmcdc_work_hour__."from_hours"::text as "0",

--- a/postgraphile/postgraphile/__tests__/queries/v4/types.sql
+++ b/postgraphile/postgraphile/__tests__/queries/v4/types.sql
@@ -1999,8 +1999,11 @@ where (
   __post__."id" = $1::"int4"
 );
 
+with __post_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __post_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __post_identifiers__,
+from __post_identifiers__,
 lateral (
   select
     __post__."id"::text as "0",
@@ -2012,8 +2015,11 @@ lateral (
   )
 ) as __post_result__;
 
+with __post_identifiers__ as materialized (
+  select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids
+)
 select __post_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __post_identifiers__,
+from __post_identifiers__,
 lateral (
   select
     __post__."id"::text as "0",


### PR DESCRIPTION
On one query that Postgres had chosen a pathological query plan for, this small change reduced execution time from 450ms to just 0.4ms - that's a 1000x performance improvement!