### PR TITLE
Make flagged value detection marginally faster

### DIFF
--- a/.changeset/all-terms-relax.md
+++ b/.changeset/all-terms-relax.md
@@ -1,0 +1,5 @@
+---
+"grafast": patch
+---
+
+Microoptimization of flagged value detection.

--- a/grafast/grafast/src/error.ts
+++ b/grafast/grafast/src/error.ts
@@ -80,8 +80,10 @@ export function flagError<TError extends Error = Error>(
  *
  * @internal
  */
-export function isFlaggedValue(value: object): value is FlaggedValue {
-  return Object.hasOwn(value, $$flagged);
+export function isFlaggedValue(value: {
+  [$$flagged]?: true;
+}): value is FlaggedValue {
+  return value[$$flagged] === true;
 }
 
 export class SafeError<


### PR DESCRIPTION
> Using the current own-Symbol representation and 98.4% ordinary-object detection:
>
> ```
>  Workload                           Object.hasOwn    value[$$flagged] === true
> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
>  Allocate flagged value + detect         15.82 ns                     15.04 ns
> ─────────────────────────────────  ───────────────  ───────────────────────────
>  Ordinary objects only                    4.86 ns                      3.77 ns
> ─────────────────────────────────  ───────────────  ───────────────────────────
>  1 in 64 flagged                          6.56 ns                      3.93 ns
> ```
> 
> The direct Symbol property check wins in every workload, particularly the overwhelmingly-not-flagged path.