### PR TITLE
Fix sideEffect inhibit bug

### DIFF
--- a/.changeset/calm-gifts-refuse.md
+++ b/.changeset/calm-gifts-refuse.md
@@ -6,5 +6,7 @@ Overhauls flag handling in grafast internals, fixing consistency and aligning
 with expectations when combining `sideEffect()`, `trap()`, `inhibitOnNull()` and
 related steps through implicit (rather than explicit) dependencies in a plan
 resolver. Fixes bug in `inhibitOnNull()` where errors from an implicit side
-effect would be captured and consumed. Optimizes layer plans: nullableBoundary
-now prevents further propagation of side effects.
+effect would be captured and consumed. Fixes bug where a side effect step that
+was inhibited would incorrectly cause steps that followed it to be inhibited
+even if they didn't depend on it. Optimizes layer plans: nullableBoundary now
+prevents further propagation of side effects.

--- a/grafast/grafast/__tests__/trap-test.ts
+++ b/grafast/grafast/__tests__/trap-test.ts
@@ -103,6 +103,7 @@ const makeSchema = () => {
         inhibitOnEmptyBoolean(value: Boolean): Boolean
         inhibitOnEmptyInt(value: Int): Int
         trapInhibitedAfterSideEffect(someList: [Int!]): [Int]
+        doesNotInheritInhibitionFromSideEffect(someList: [Int!]): Int
         inhibitIfList(value: [Int!]): [Int]!
         inhibitIfPreservesErrors(setNullToError: Int): Int
         inhibitIfPreservesInhibition(setNullToNull: Int): Int
@@ -197,6 +198,13 @@ const makeSchema = () => {
             return trap($b, TRAP_INHIBITED, {
               valueForInhibited: "EMPTY_LIST",
             });
+          },
+          doesNotInheritInhibitionFromSideEffect(_, { $someList }) {
+            const $a = inhibitOnEmpty($someList);
+            sideEffect($a, () => {
+              throw new Error("This side effect should be inhibited");
+            });
+            return lambda(null, () => 42);
           },
           inhibitIfList(_, { $value }) {
             const $isEmpty = lambda($value, (list) => list.length === 0, true);
@@ -545,6 +553,20 @@ it("traps inhibition inherited through a side effect", async () => {
   })) as ExecutionResult;
   expect(result).to.deep.equal({
     data: { trapInhibitedAfterSideEffect: [] },
+  });
+});
+
+it("does not inherit inhibition from an implicit side effect", async () => {
+  const result = (await grafast({
+    source: /* GraphQL */ `
+      query Q {
+        doesNotInheritInhibitionFromSideEffect(someList: [])
+      }
+    `,
+    schema: makeSchema(),
+  })) as ExecutionResult;
+  expect(result).to.deep.equal({
+    data: { doesNotInheritInhibitionFromSideEffect: 42 },
   });
 });
 

--- a/grafast/grafast/__tests__/trap-test.ts
+++ b/grafast/grafast/__tests__/trap-test.ts
@@ -102,6 +102,7 @@ const makeSchema = () => {
         inhibitOnEmptyInput(input: EmptyableInput): String
         inhibitOnEmptyBoolean(value: Boolean): Boolean
         inhibitOnEmptyInt(value: Int): Int
+        trapInhibitedAfterSideEffect(someList: [Int!]): [Int]
         inhibitIfList(value: [Int!]): [Int]!
         inhibitIfPreservesErrors(setNullToError: Int): Int
         inhibitIfPreservesInhibition(setNullToNull: Int): Int
@@ -181,6 +182,20 @@ const makeSchema = () => {
             const $guarded = inhibitOnEmpty($value);
             return trap($guarded, TRAP_INHIBITED, {
               valueForInhibited: "NULL",
+            });
+          },
+          trapInhibitedAfterSideEffect(_, { $someList }) {
+            const $a = inhibitOnEmpty($someList);
+            sideEffect($a, () => {
+              throw new Error("This side effect should be inhibited");
+            });
+            const $b = lambda(
+              $a,
+              (list: number[]) => list.map((n) => n + 1),
+              true,
+            );
+            return trap($b, TRAP_INHIBITED, {
+              valueForInhibited: "EMPTY_LIST",
             });
           },
           inhibitIfList(_, { $value }) {
@@ -516,6 +531,20 @@ it("supports inhibitIf and inhibitOnEmpty", async () => {
     inhibitEmptyList: [], // No `0` prefixed, so inhibited
     inhibitNonEmptyList: [0, 4, 5],
     preservedInhibition: null, // If inhibition was lost, this would be 42
+  });
+});
+
+it("traps inhibition inherited through a side effect", async () => {
+  const result = (await grafast({
+    source: /* GraphQL */ `
+      query Q {
+        trapInhibitedAfterSideEffect(someList: [])
+      }
+    `,
+    schema: makeSchema(),
+  })) as ExecutionResult;
+  expect(result).to.deep.equal({
+    data: { trapInhibitedAfterSideEffect: [] },
   });
 });
 

--- a/grafast/grafast/src/engine/executeBucket.ts
+++ b/grafast/grafast/src/engine/executeBucket.ts
@@ -1146,7 +1146,18 @@ export function executeBucket(
       const $sideEffect = step.implicitSideEffectStep;
       if ($sideEffect) {
         if ($sideEffect._isUnary || !step._isUnary) {
-          addDependency($sideEffect, defaultForbiddenFlags, undefined);
+          addDependency(
+            $sideEffect,
+            // An **implicit** side effect dependency should cause steps to error
+            // (by default) if it itself errored; however, if the side effect was
+            // inhibited then further steps should not be impacted - the side
+            // effect never ran. (A side effect saying dependents should be
+            // inhibited, by returning `$$inhibit` itself, should only be
+            // relevant to dependents that _explicitly_ depend on the side
+            // effect, not implicitly by merely following it.)
+            defaultForbiddenFlags & FLAG_ERROR,
+            undefined,
+          );
         }
       }
       if (

--- a/grafast/grafast/src/steps/__flag.ts
+++ b/grafast/grafast/src/steps/__flag.ts
@@ -137,13 +137,15 @@ export class __FlagStep<TStep extends Step>
     this.valueForInhibited = resolveTrapValue(valueForInhibited);
     this.valueForError = resolveTrapValue(valueForError);
     const trapsErrors = (acceptFlags & FLAG_ERROR) === FLAG_ERROR;
-    const trapsInhibition = (acceptFlags & FLAG_INHIBITED) === FLAG_INHIBITED;
-    const trapsSideEffectFlags = trapsErrors || trapsInhibition;
     this.canBeInlined =
-      !trapsSideEffectFlags &&
+      (!trapsErrors || !this.implicitSideEffectStep) &&
       !$cond &&
       valueForInhibited === "PASS_THROUGH" &&
-      valueForError === "PASS_THROUGH";
+      valueForError === "PASS_THROUGH" &&
+      // Can't PASS_THROUGH errors since they need to be converted into TRAPPED
+      // error.
+      // TODO: should we be handling this in Grafast core?
+      !trapsErrors;
     if (!this.canBeInlined) {
       this.addDependency({ step, acceptFlags: TRAPPABLE_FLAGS });
       if ($cond) {
@@ -156,7 +158,7 @@ export class __FlagStep<TStep extends Step>
       this.listItem = this._listItem;
     }
     if (
-      trapsSideEffectFlags &&
+      trapsErrors &&
       (this.implicitSideEffectStep || this.layerPlan.latestSideEffectStep)
     ) {
       if (this.implicitSideEffectStep !== this.layerPlan.latestSideEffectStep) {
@@ -165,7 +167,7 @@ export class __FlagStep<TStep extends Step>
         );
       }
 
-      // We've been instructed to capture flags from the side effect.
+      // We've been instructed to capture errors.
       // Need to make this have the side effect, to prevent us being inlined.
       this.hasSideEffects = true;
       this.layerPlan.latestSideEffectStep = this;

--- a/grafast/grafast/src/steps/__flag.ts
+++ b/grafast/grafast/src/steps/__flag.ts
@@ -137,15 +137,13 @@ export class __FlagStep<TStep extends Step>
     this.valueForInhibited = resolveTrapValue(valueForInhibited);
     this.valueForError = resolveTrapValue(valueForError);
     const trapsErrors = (acceptFlags & FLAG_ERROR) === FLAG_ERROR;
+    const trapsInhibition = (acceptFlags & FLAG_INHIBITED) === FLAG_INHIBITED;
+    const trapsSideEffectFlags = trapsErrors || trapsInhibition;
     this.canBeInlined =
-      (!trapsErrors || !this.implicitSideEffectStep) &&
+      !trapsSideEffectFlags &&
       !$cond &&
       valueForInhibited === "PASS_THROUGH" &&
-      valueForError === "PASS_THROUGH" &&
-      // Can't PASS_THROUGH errors since they need to be converted into TRAPPED
-      // error.
-      // TODO: should we be handling this in Grafast core?
-      !trapsErrors;
+      valueForError === "PASS_THROUGH";
     if (!this.canBeInlined) {
       this.addDependency({ step, acceptFlags: TRAPPABLE_FLAGS });
       if ($cond) {
@@ -158,7 +156,7 @@ export class __FlagStep<TStep extends Step>
       this.listItem = this._listItem;
     }
     if (
-      trapsErrors &&
+      trapsSideEffectFlags &&
       (this.implicitSideEffectStep || this.layerPlan.latestSideEffectStep)
     ) {
       if (this.implicitSideEffectStep !== this.layerPlan.latestSideEffectStep) {
@@ -167,7 +165,7 @@ export class __FlagStep<TStep extends Step>
         );
       }
 
-      // We've been instructed to capture errors.
+      // We've been instructed to capture flags from the side effect.
       // Need to make this have the side effect, to prevent us being inlined.
       this.hasSideEffects = true;
       this.layerPlan.latestSideEffectStep = this;

--- a/grafast/website/grafast/plan-resolvers/index.mdx
+++ b/grafast/website/grafast/plan-resolvers/index.mdx
@@ -588,6 +588,9 @@ key rules:
 
 1. Dependencies before dependents.
 2. Steps **implicitly** depend on the most recent side effect step, if any.
+   This preserves ordering and, by default, propagates side-effect errors. It
+   does not propagate inhibition: an inhibited side effect did not run.
+   Inhibition only propagates through explicit data dependencies.
 
 This can be surprising during mutations: steps created before a mutation might
 execute **after** the mutation unless one of the rules above says otherwise.

--- a/grafast/website/grafast/standard-steps/sideEffect.md
+++ b/grafast/website/grafast/standard-steps/sideEffect.md
@@ -26,6 +26,19 @@ issue.
 `sideEffect` does not perform batching; it is only intended for performing
 mutations, and mutations rarely batch.
 
+## Errors and inhibition
+
+Steps created after a side effect implicitly wait for it to complete. By
+default, if the side effect yields an error, the error prevents those later
+steps from running. However, if the side effect is inhibited then it did not
+run, so that inhibition does not propagate merely because a step was created
+later.
+
+To make inhibition propagate, create an explicit data dependency on the side
+effect, either directly or through other steps. This is appropriate when the
+later step needs the value represented by the side effect; otherwise, it only
+needs the ordering guarantee.
+
 :::tip[Mark any step as having side effects]
 
 Almost any step can be made to be treated as having side effects by setting


### PR DESCRIPTION
Prior to this if a sideEffect was inhibited, anything that implicitly followed it would be inhibited. This was not the intended behavior - errors from side effects should propagate, but if a side effect is inhibited then it didn't run and later steps should be unaffected by it.